### PR TITLE
Fix some comparison operators.

### DIFF
--- a/lslmini.y
+++ b/lslmini.y
@@ -857,17 +857,17 @@ expression
 	}
 	| expression NEQ expression
 	{
-		$$ = new LLScriptExpression( new LLScriptExpression( $1, EQ, $3 ), '!' );
+		$$ = new LLScriptExpression( $1, NEQ, $3 );
 	}
 	| expression LEQ expression
 	{
-		// if ( A <= B ) B > A
-		$$ = new LLScriptExpression( $3, '>', $1 );
+		// (A <= B) is equivalent to !(A > B)
+		$$ = new LLScriptExpression(new LLScriptExpression( $1, '>', $3 ), '!');
 	}
 	| expression GEQ expression
 	{
-		// if ( A >= B ) B < A
-		$$ = new LLScriptExpression( $3, '<', $1 );
+		// (A >= B) is equivalent to !(A < B)
+		$$ = new LLScriptExpression(new LLScriptExpression( $1, '<', $3 ), '!');
 	}
 	| expression '<' expression
 	{

--- a/scripts/comparison.lsl
+++ b/scripts/comparison.lsl
@@ -1,0 +1,13 @@
+default{timer(){
+
+if ([1,2] != [] == 2) 0; // $[E20012] always true
+if ([1,2] != [] == 1) 0; // $[E20013] always false
+
+if (3 >= 3) 0; // $[E20012] always true
+if (3 >= 2) 0; // $[E20012] always true
+if (2 >= 3) 0; // $[E20013] always false
+if (3 <= 3) 0; // $[E20012] always true
+if (2 <= 3) 0; // $[E20012] always true
+if (3 <= 2) 0; // $[E20013] always false
+
+}}

--- a/scripts/comparison.lso.lsl
+++ b/scripts/comparison.lso.lsl
@@ -1,0 +1,5 @@
+default{timer(){
+
+if ("" != "xx" == -1) 0; // $[E20012] always true in LSO
+
+}}

--- a/scripts/comparison.mono.lsl
+++ b/scripts/comparison.mono.lsl
@@ -1,0 +1,5 @@
+default{timer(){
+
+if ("" != "xx" == 1) 0; // $[E20012] always true in Mono
+
+}}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+failed=.
+if [ -e ./test.total.txt ] ; then
+    rm -f ./test.total.txt
+fi
+
+for f in scripts/*.lsl scripts/*/*.lsl ; do
+  printf "%40s ... " "$f"
+  if [ "${f%.mono.lsl}" != "$f" ] ; then
+    ./lslint -m -\# -A "$f" > ./test.run.txt 2>&1
+  elif [ "${f%.lso.lsl}" != "$f" ] ; then
+    ./lslint -m- -\# -A "$f" > ./test.run.txt 2>&1
+  else
+    # test in both modes
+    ./lslint -m -\# -A "$f" > ./test.run.txt 2>&1
+    ./lslint -m- -\# -A "$f" > ./test.run.txt 2>&1
+  fi
+  if [ $? != 0 ] ; then
+      echo "FAILED"
+      echo "" >> ./test.total.txt
+      echo "****************" >> ./test.total.txt
+      echo '***>' "$f" >> ./test.total.txt
+      echo "" >> ./test.total.txt
+       cat ./test.run.txt >> ./test.total.txt
+      failed=$failed.
+  else
+      echo "passed"
+  fi
+done
+
+rm -f ./test.run.txt
+
+if [ $failed != . ] ; then
+  cat ./test.total.txt
+  rm -f ./test.total.txt
+fi

--- a/types.cc
+++ b/types.cc
@@ -118,7 +118,18 @@ const static int operator_result_table[][4] = {
    { EQ,         LST_KEY,            LST_KEY,            LST_BOOLEAN         },
    { EQ,         LST_LIST,           LST_LIST,           LST_BOOLEAN         }, // compares list lengths
 
-   // != -- converted to ! EQ by parser
+   // !=
+   { NEQ,         LST_INTEGER,        LST_INTEGER,        LST_BOOLEAN         }, 
+   { NEQ,         LST_INTEGER,        LST_FLOATINGPOINT,  LST_BOOLEAN         },
+   { NEQ,         LST_FLOATINGPOINT,  LST_INTEGER,        LST_BOOLEAN         },
+   { NEQ,         LST_FLOATINGPOINT,  LST_FLOATINGPOINT,  LST_BOOLEAN         },
+   { NEQ,         LST_VECTOR,         LST_VECTOR,         LST_BOOLEAN         },
+   { NEQ,         LST_QUATERNION,     LST_QUATERNION,     LST_BOOLEAN         },
+   { NEQ,         LST_STRING,         LST_STRING,         LST_BOOLEAN         },
+   { NEQ,         LST_STRING,         LST_KEY,            LST_BOOLEAN         }, // strcmp in LSO, != in Mono
+   { NEQ,         LST_KEY,            LST_STRING,         LST_BOOLEAN         },
+   { NEQ,         LST_KEY,            LST_KEY,            LST_BOOLEAN         },
+   { NEQ,         LST_LIST,           LST_LIST,           LST_BOOLEAN         }, // subtracts list lengths
 
    // bitwise operators
    { '&',        LST_INTEGER,        LST_INTEGER,        LST_INTEGER         },


### PR DESCRIPTION
X >= X and X <= X evaluated to false, not to true.

X != Y didn't work correctly for lists, and in the case of LSO, for strings.

Add regression tests and a new `sh` regression testing script.

The new `sh` script implements the different testing for Mono and LSO discussed in #17, though it's somewhat incomplete because it doesn't allow for testing other syntax variations (in particular preprocessor, switch statements, lazy lists).