### PR TITLE
Move error messages to their original places, to get the numbers right.

### DIFF
--- a/logger.cc
+++ b/logger.cc
@@ -236,61 +236,69 @@ LogMessage::~LogMessage() {
 
 /// ERROR MESSAGE
 
+/****************************************************************************
+  IMPORTANT: Do not add messages here without having added the corresponding
+             enum first in logger.hh; see caveats there.
+ ****************************************************************************/
+
 const char *Logger::error_messages[] = {
-   "ERROR",
-   "Duplicate declaration of `%s'; previously declared at (%d, %d).",
-   "Invalid operator: %s %s %s.",
-   "`%s' is deprecated.",
-   "`%s' is deprecated, use %s instead.",
-   "Attempting to use `%s' as a %s, but it is a %s.",
-   "`%s' is undeclared.",
-   "`%s' is undeclared; did you mean %s?",
-   "Invalid member: `%s.%s'.",
-   "Trying to access `%s.%s', but `%1$s' is a %3$s",
-   "Attempting to access `%s.%s', but `%1$s' is not a vector or rotation.",
-   "Passing %s as argument %d of `%s' which is declared as `%s %s'.",
-   "Too many arguments to function `%s'.",
-   "Too few arguments to function `%s'.",
-   "Functions cannot change state.",
-   "`%s %s' assigned a %s value.",
-   "%s member assigned %s value (must be float or integer).",
-   "Event handlers cannot return a value.",
-   "Returning a %s value from a %s function.",
-   "Not all code paths return a value.",
-   "%s", // Syntax error, bison includes all the info.
-   "Global initializer must be constant.",
-   "State must have at least one event handler.",
-   "`%s' is a constant and cannot be used as an lvalue.",
-   "`%s' is a constant and cannot be used in a variable declaration.",
-   "Declaring `%s' as parameter %d of `%s' which should be `%s %s'.",
-   "Too many parameters for event `%s'.",
-   "Too few parameters for event `%s'.",
-   "`%s' is not a valid event name.",
-   "`%s' is an event name, and cannot be used as a function name.",
-   "Multiple handlers for event `%s'.",
+   "ERROR",                                                           // 10000
+   "Duplicate declaration of `%s'; previously declared at (%d, %d).", // 10001
+   "Invalid operator: %s %s %s.",                                     // 10002
+   "`%s' is deprecated.",                                             // 10003
+   "`%s' is deprecated, use %s instead.",                             // 10004
+   "Attempting to use `%s' as a %s, but it is a %s.",                 // 10005
+   "`%s' is undeclared.",                                             // 10006
+   "`%s' is undeclared; did you mean %s?",                            // 10007
+   "Invalid member: `%s.%s'.",                                        // 10008
+   "Trying to access `%s.%s', but `%1$s' is a %3$s",                  // 10009
+   "Attempting to access `%s.%s', but `%1$s' is not a vector or rotation.", // 10010
+   "Passing %s as argument %d of `%s' which is declared as `%s %s'.", // 10011
+   "Too many arguments to function `%s'.",                            // 10012
+   "Too few arguments to function `%s'.",                             // 10013
+   "Functions cannot change state.",                                  // 10014
+   "`%s %s' assigned a %s value.",                                    // 10015
+   "%s member assigned %s value (must be float or integer).",         // 10016
+   "Event handlers cannot return a value.",                           // 10017
+   "Returning a %s value from a %s function.",                        // 10018
+   "%s", // Syntax error, bison includes all the info.                // 10019
+   "Global initializer must be constant.",                            // 10020
+   "Expression and constant without operator.",                       // 10021
+   "State must have at least one event handler.",                     // 10022
+   "",                                                                // 10023
+   "`%s' is a constant and cannot be used as an lvalue.",             // 10024
+   "`%s' is a constant and cannot be used in a variable declaration.", // 10025
+   "Not all code paths return a value.",                              // 10026
+   "Declaring `%s' as parameter %d of `%s' which should be `%s %s'.", // 10027
+   "Too many parameters for event `%s'.",                             // 10028
+   "Too few parameters for event `%s'.",                              // 10029
+   "`%s' is not a valid event name.",                                 // 10030
+   "`%s' is an event name, and cannot be used as a function name.",   // 10031
+   "Multiple handlers for event `%s'.",                               // 10032
 
 };
 
 const char *Logger::warning_messages[] = {
-   "WARN",
-   "Declaration of `%s' in this scope shadows previous declaration at (%d, %d)",
-   "Suggest parentheses around assignment used as truth value.",
+   "WARN",                                                            // 20000
+   "Declaration of `%s' in this scope shadows previous declaration at (%d, %d)",  // 20001
+   "Suggest parentheses around assignment used as truth value.",      // 20002
    "Changing state to current state acts the same as return. (SL1.8.3)\n"
-      "If this is what you intended, consider using return instead.",
+      "If this is what you intended, consider using return instead.", // 20003
    "Changing state in a list or string function will corrupt the stack.\n"
       "Using the return value from this function will cause a run-time bounds check error.\n"
-      "See: http://secondlife.com/badgeo/wakka.php?wakka=FunctionStateChangeHack",
+      "See: http://secondlife.com/badgeo/wakka.php?wakka=FunctionStateChangeHack", // 20004
    "Using an if statement to change state in a function is a hack and may have unintended side-effects.\n"
-      "See: http://secondlife.com/badgeo/wakka.php?wakka=FunctionStateChangeHack",
-   "Multiple jumps for label `%s' - only the last will execute.",
-   "Empty if statement.",
+      "See: http://secondlife.com/badgeo/wakka.php?wakka=FunctionStateChangeHack", // 20005
+   "Multiple jumps for label `%s' - only the last will execute.",     // 20006
+   "Empty if statement.",                                             // 20007
    "`%s' treated as %d; this is probably not what you wanted.\n"
       "Make sure you separate opeartors with spaces.\n"
-      "See: http://forums.secondlife.com/showthread.php?t=60257",
-   "%s `%s' declared but never used.",
-   "Unused event parameter `%s'.",
+      "See: http://forums.secondlife.com/showthread.php?t=60257",     // 20008
+   "%s `%s' declared but never used.",                                // 20009
    "Using == on lists only compares lengths.\n"
-      "See: http://secondlife.com/badgeo/wakka.php?wakka=annoyances",
-   "Condition is always true.",
-   "Condition is always false.",
+      "See: http://secondlife.com/badgeo/wakka.php?wakka=annoyances", // 20010
+   "Condition is always true.",                                       // 20011
+   "Condition is always false.",                                      // 20012
+   "",                                                                // 20013 (unused)
+   "Unused event parameter `%s'.",                                    // 20014
 };

--- a/logger.hh
+++ b/logger.hh
@@ -34,61 +34,73 @@ enum LogLevel {
 };
 
 enum ErrorCode {
+    /***********************************************************************
+     IMPORTANT NOTES:
+       - The order of these errors must match the order of the corresponding
+         messages in logger.cc.
+       - The same applies both to the errors and to the warnings.
+       - The numeric codes are used in the test suite. Don't remove one from
+         the middle: change it to E_removed_NNN or to W_removed_NNN instead,
+         and the corresponding text in logger.cc to "".
+       - Add new codes to the end, right before E_LAST or W_LAST.
+     ***********************************************************************/
+
     // errors
     E_ERROR                 = 10000,
-    E_DUPLICATE_DECLARATION,
-    E_INVALID_OPERATOR,
-    E_DEPRECATED,
-    E_DEPRECATED_WITH_REPLACEMENT,
-    E_WRONG_TYPE,
-    E_UNDECLARED,
-    E_UNDECLARED_WITH_SUGGESTION,
-    E_INVALID_MEMBER,
-    E_MEMBER_NOT_VARIABLE,
-    E_MEMBER_WRONG_TYPE,
-    E_ARGUMENT_WRONG_TYPE,
-    E_TOO_MANY_ARGUMENTS,
-    E_TOO_FEW_ARGUMENTS,
-    E_CHANGE_STATE_IN_FUNCTION,
-    E_WRONG_TYPE_IN_ASSIGNMENT,
-    E_WRONG_TYPE_IN_MEMBER_ASSIGNMENT,
-    E_RETURN_VALUE_IN_EVENT_HANDLER,
-    E_BAD_RETURN_TYPE,
-    E_NOT_ALL_PATHS_RETURN,
-    E_SYNTAX_ERROR,
-    E_GLOBAL_INITIALIZER_NOT_CONSTANT,
-    E_NO_EVENT_HANDLERS,
-    E_BUILTIN_LVALUE,
-    E_SHADOW_CONSTANT,
-    E_ARGUMENT_WRONG_TYPE_EVENT,
-    E_TOO_MANY_ARGUMENTS_EVENT,
-    E_TOO_FEW_ARGUMENTS_EVENT,
-    E_INVALID_EVENT,
-    E_DUPLICATE_DECLARATION_EVENT,
-    E_MULTIPLE_EVENT_HANDLERS,
+    E_DUPLICATE_DECLARATION,           // 10001
+    E_INVALID_OPERATOR,                // 10002
+    E_DEPRECATED,                      // 10003
+    E_DEPRECATED_WITH_REPLACEMENT,     // 10004
+    E_WRONG_TYPE,                      // 10005
+    E_UNDECLARED,                      // 10006
+    E_UNDECLARED_WITH_SUGGESTION,      // 10007
+    E_INVALID_MEMBER,                  // 10008
+    E_MEMBER_NOT_VARIABLE,             // 10009
+    E_MEMBER_WRONG_TYPE,               // 10010
+    E_ARGUMENT_WRONG_TYPE,             // 10011
+    E_TOO_MANY_ARGUMENTS,              // 10012
+    E_TOO_FEW_ARGUMENTS,               // 10013
+    E_CHANGE_STATE_IN_FUNCTION,        // 10014
+    E_WRONG_TYPE_IN_ASSIGNMENT,        // 10015
+    E_WRONG_TYPE_IN_MEMBER_ASSIGNMENT, // 10016
+    E_RETURN_VALUE_IN_EVENT_HANDLER,   // 10017
+    E_BAD_RETURN_TYPE,                 // 10018
+    E_SYNTAX_ERROR,                    // 10019
+    E_GLOBAL_INITIALIZER_NOT_CONSTANT, // 10020
+    E_NO_OPERATOR,                     // 10021
+    E_NO_EVENT_HANDLERS,               // 10022
+    E_removed_1,                       // 10023
+    E_BUILTIN_LVALUE,                  // 10024
+    E_SHADOW_CONSTANT,                 // 10025
+    E_NOT_ALL_PATHS_RETURN,            // 10026
+    E_ARGUMENT_WRONG_TYPE_EVENT,       // 10027
+    E_TOO_MANY_ARGUMENTS_EVENT,        // 10028
+    E_TOO_FEW_ARGUMENTS_EVENT,         // 10029
+    E_INVALID_EVENT,                   // 10030
+    E_DUPLICATE_DECLARATION_EVENT,     // 10031
+    E_MULTIPLE_EVENT_HANDLERS,         // 10032
     E_LAST,
-    
-    
+
 
 
     // warnings
     W_WARNING               = 20000,
-    W_SHADOW_DECLARATION,
-    W_ASSIGNMENT_IN_COMPARISON,
-    W_CHANGE_TO_CURRENT_STATE,
-    W_CHANGE_STATE_HACK_CORRUPT,
-    W_CHANGE_STATE_HACK,
-    W_MULTIPLE_JUMPS_FOR_LABEL,
-    W_EMPTY_IF,
-    W_BAD_DECIMAL_LEX,
-    W_DECLARED_BUT_NOT_USED,
-    W_UNUSED_EVENT_PARAMETER,
-    W_LIST_COMPARE,
-    W_CONDITION_ALWAYS_TRUE,
-    W_CONDITION_ALWAYS_FALSE,
+    W_SHADOW_DECLARATION,              // 20001
+    W_ASSIGNMENT_IN_COMPARISON,        // 20002
+    W_CHANGE_TO_CURRENT_STATE,         // 20003
+    W_CHANGE_STATE_HACK_CORRUPT,       // 20004
+    W_CHANGE_STATE_HACK,               // 20005
+    W_MULTIPLE_JUMPS_FOR_LABEL,        // 20006
+    W_EMPTY_IF,                        // 20007
+    W_BAD_DECIMAL_LEX,                 // 20008
+    W_DECLARED_BUT_NOT_USED,           // 20009
+    W_LIST_COMPARE,                    // 20010
+    W_CONDITION_ALWAYS_TRUE,           // 20011
+    W_CONDITION_ALWAYS_FALSE,          // 20012
+    W_removed_1,                       // 20013
+    W_UNUSED_EVENT_PARAMETER,          // 20014
     W_LAST,
-    
-    
+
 };
 
 #define LOG         Logger::get()->log

--- a/scripts/comparison.lsl
+++ b/scripts/comparison.lsl
@@ -1,13 +1,13 @@
 default{timer(){
 
-if ([1,2] != [] == 2) 0; // $[E20012] always true
-if ([1,2] != [] == 1) 0; // $[E20013] always false
+if ([1,2] != [] == 2) 0; // $[E20011] always true
+if ([1,2] != [] == 1) 0; // $[E20012] always false
 
-if (3 >= 3) 0; // $[E20012] always true
-if (3 >= 2) 0; // $[E20012] always true
-if (2 >= 3) 0; // $[E20013] always false
-if (3 <= 3) 0; // $[E20012] always true
-if (2 <= 3) 0; // $[E20012] always true
-if (3 <= 2) 0; // $[E20013] always false
+if (3 >= 3) 0; // $[E20011] always true
+if (3 >= 2) 0; // $[E20011] always true
+if (2 >= 3) 0; // $[E20012] always false
+if (3 <= 3) 0; // $[E20011] always true
+if (2 <= 3) 0; // $[E20011] always true
+if (3 <= 2) 0; // $[E20012] always false
 
 }}

--- a/scripts/comparison.lso.lsl
+++ b/scripts/comparison.lso.lsl
@@ -1,5 +1,5 @@
 default{timer(){
 
-if ("" != "xx" == -1) 0; // $[E20012] always true in LSO
+if ("" != "xx" == -1) 0; // $[E20011] always true in LSO
 
 }}

--- a/scripts/comparison.mono.lsl
+++ b/scripts/comparison.mono.lsl
@@ -1,5 +1,5 @@
 default{timer(){
 
-if ("" != "xx" == 1) 0; // $[E20012] always true in Mono
+if ("" != "xx" == 1) 0; // $[E20011] always true in Mono
 
 }}


### PR DESCRIPTION
Also add a much needed comment about usage of that enum and messages.

Addresses part of #17.

This is the first PR aimed at fixing #17. It will conflict with #15 for sure. It's not easy to get the order right so please review this one first and merge if suitable; then I'll rebase #15. The test cases in #18 will also be affected.

EDIT: With this, the number of passed tests increases by 6 and is now 31.