### PR TITLE
Fix global expressions again.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,21 @@ endif
 
 OBJS = lslmini.tab.o lex.yy.o lslmini.o symtab.o builtins.o builtins_txt.o types.o values.o final_walk.o operators.o logger.o
 
+all: $(PROGRAM)
+
 $(PROGRAM): $(OBJS)
 	$(LD) $(LDOUTPUT)"$@" $^
 	$(UPX) "$@"
 
 clean:
 	rm -f $(OBJS) lex.yy.c lslint lslmini.tab.c lslmini.tab.h
+
+ifndef WINDOWS
+
+check: all
+	sh test.sh
+
+endif
 
 $(OBJS): lslmini.hh
 
@@ -116,3 +125,5 @@ lex.yy.c: lslmini.l
 
 .c.o .cc.o:
 	$(CXX) $(CXXOUTPUT)"$@" -c $<
+
+.PHONY: all clean check

--- a/ast.hh
+++ b/ast.hh
@@ -78,6 +78,8 @@ class LLASTNode {
       va_end(ap);
     }
 
+    virtual ~LLASTNode() { }
+
     void add_children( int num, va_list vp );
 
     LLASTNode *get_next() { return next; }

--- a/lslmini.cc
+++ b/lslmini.cc
@@ -203,10 +203,6 @@ void LLScriptGlobalVariable::define_symbols() {
       identifier->get_symbol()->set_constant_value( get_child(1)->get_child(0)->get_constant_value() );
 }
 
-void LLScriptScript::define_symbols() {
-   define_builtins();
-}
-
 void LLScriptState::define_symbols() {
    LLASTNode             *node = get_children();
    LLScriptIdentifier    *identifier;

--- a/lslmini.hh
+++ b/lslmini.hh
@@ -108,6 +108,7 @@ class LLScriptGlobalVariable : public LLASTNode {
     virtual char *get_node_name() { return "global var"; }
     virtual LLNodeType get_node_type() { return NODE_GLOBAL_VARIABLE; };
     virtual void determine_type();
+    virtual void determine_value();
 
     void cil_declare();
 };

--- a/lslmini.hh
+++ b/lslmini.hh
@@ -52,7 +52,9 @@ class LLScriptScript : public LLASTNode {
       : LLASTNode( 2, globals, states ) {
         symbol_table = new LLScriptSymbolTable();
     };
-    virtual void define_symbols();
+    LLScriptScript() : LLASTNode( 0 ) {
+        symbol_table = new LLScriptSymbolTable();
+    };
 #ifdef COMPILE_ENABLED
     virtual void generate_cil();
 #endif /* COMPILE_ENABLED */
@@ -134,7 +136,7 @@ class LLScriptConstant : public LLASTNode {
 
 class LLScriptIntegerConstant : public LLScriptConstant {
   public:
-    LLScriptIntegerConstant( int v ) : LLScriptConstant(), value(v) { type = TYPE(LST_INTEGER); }
+    LLScriptIntegerConstant( int v, int isbool = 0 ) : LLScriptConstant(), value(v), is_bool(isbool) { type = TYPE(LST_INTEGER); }
 
     virtual char *get_node_name() {
       static char buf[256];
@@ -145,10 +147,12 @@ class LLScriptIntegerConstant : public LLScriptConstant {
     virtual LLNodeSubType get_node_sub_type() { return NODE_INTEGER_CONSTANT; }
 
     int get_value() { return value; }
+    int get_is_bool() { return is_bool; }
     virtual LLScriptConstant *operation(int op, LLScriptConstant *other_const, YYLTYPE *lloc);
 
   private:
     int value;
+    int is_bool;
 };
 
 

--- a/scripts/globals.lsl
+++ b/scripts/globals.lsl
@@ -51,6 +51,8 @@ vector good_v02 = <-0.0, 0.0, 0.0>;
 vector good_v03 = <- 0.0, 1, -2>;
 
 rotation good_r00;
+rotation good_r01 = <1,2,3,4>;
+rotation good_r02 = good_r01;
 
 list good_l00;
 list good_l01 = [];
@@ -74,6 +76,8 @@ float bad_f03 = -TRUE;       // $[E10020]
 float bad_f04 = -good_f01;   // $[E10020]
 string bad_s01 = - "what?";  // $[E10020]
 vector bad_v01 = -<1,2,3>;   // $[E10020]
+vector bad_v02 = <1,2,[]>;   // $[E10020]
+vector bad_r01 = -r00;       // $[E10020]
 list bad_l01 = [-TRUE];      // $[E10020]
 list bad_l02 = [-<1,1,1>];   // $[E10020]
 list bad_l03 = [1,[2,3],4];  // $[E10020] TODO: add "Lists can't contain lists"
@@ -121,6 +125,7 @@ if (good_k00 == good_k00)        0; // $[E20011]
 if (good_v00 == ZERO_VECTOR)     0; // $[E20011]
 if (good_v00 == good_v01)        0; // $[E20011]
 if (good_r00 == ZERO_ROTATION)   0; // $[E20011]
+if (good_r02 == <1,2,3,4>)       0; // $[E20011]
 if (good_l00 == [])              0; // $[E20011]
 if (good_l01 == [])              0; // $[E20011]
 if (good_l00 == good_l01)        0; // $[E20011]

--- a/scripts/globals.lsl
+++ b/scripts/globals.lsl
@@ -10,6 +10,8 @@ integer good_i06 = ALL_SIDES;
 integer good_i07 = -ALL_SIDES;
 integer good_i08 = - ALL_SIDES;
 integer good_i09 = good_i01;
+integer good_i10 = good_i09;
+integer good_i11 = good_i00;
 
 float good_f00;
 float good_f01 = 1;
@@ -48,13 +50,15 @@ vector good_v01 = <0, 0, 0>;
 vector good_v02 = <-0.0, 0.0, 0.0>;
 vector good_v03 = <- 0.0, 1, -2>;
 
+rotation good_r00;
+
 list good_l00;
 list good_l01 = [];
-list good_l02 = [<1,2,3>,<-1,2,3>, -1, TRUE, -ALL_SIDES, PI, - PI];
+list good_l02 = [<1,2,3>, <-1,2,3>, -1, TRUE, -ALL_SIDES, PI, - PI];
 
 // Bad:
 
-integer bad_i01 = -TRUE;     // $[E10020]
+integer bad_i01 = -TRUE;     // $[E10020] global initializer must be constant
 integer bad_i02 = -FALSE;    // $[E10020]
 integer bad_i03 = -ZERO_VECTOR;    // $[E10020]
 integer bad_i04 = -ZERO_ROTATION;  // $[E10020]
@@ -97,12 +101,30 @@ default{timer(){
 (string)[-TRUE, -<0,0,0>, ~1];
 
 // Bad
-(string)-TRUE;     // $[E10019]
+(string)-TRUE;     // $[E10019] syntax error
 (string) - FALSE;  // $[E10019]
 (string)~1;        // $[E10019]
 (string)-<0,0,0>;  // $[E10019]
 (string)-good_i01; // $[E10019]
-(string)[-"nope"]; // $[E10002]
+(string)[-"nope"]; // $[E10002] invalid operator
+
+if (good_i00 == 0)               0; // $[E20011] always true
+if (good_i00 == good_i00)        0; // $[E20011]
+if (good_i01 == 1)               0; // $[E20011]
+if (good_i09 == 1)               0; // $[E20011]
+if (good_i10 == 1)               0; // $[E20011]
+if (good_i11 == 0)               0; // $[E20011]
+if (good_f00 == 0.)              0; // $[E20011]
+if (good_s00 == "")              0; // $[E20011]
+if (good_k00 == "")              0; // $[E20011]
+if (good_k00 == good_k00)        0; // $[E20011]
+if (good_v00 == ZERO_VECTOR)     0; // $[E20011]
+if (good_v00 == good_v01)        0; // $[E20011]
+if (good_r00 == ZERO_ROTATION)   0; // $[E20011]
+if (good_l00 == [])              0; // $[E20011]
+if (good_l01 == [])              0; // $[E20011]
+if (good_l00 == good_l01)        0; // $[E20011]
+if (good_l02 == [0,0,0,0,0,0,0]) 0; // $[E20011] $[E20010] compares lengths
 
 // Use variables to avoid extra warnings
 good_i00; good_i01; good_i02; good_i03; good_i04;

--- a/scripts/globals.lsl
+++ b/scripts/globals.lsl
@@ -1,0 +1,126 @@
+// Good:
+
+integer good_i00;
+integer good_i01 = 1;
+integer good_i02 = -1;
+integer good_i03 = - 1;
+integer good_i04 = TRUE;
+integer good_i05 = FALSE;
+integer good_i06 = ALL_SIDES;
+integer good_i07 = -ALL_SIDES;
+integer good_i08 = - ALL_SIDES;
+integer good_i09 = good_i01;
+
+float good_f00;
+float good_f01 = 1;
+float good_f02 = -1;
+float good_f03 = - 1;
+float good_f04 = TRUE;
+float good_f05 = FALSE;
+float good_f06 = -ALL_SIDES;
+float good_f07 = - ALL_SIDES;
+float good_f08 = good_i01;
+float good_f09 = good_f01;
+float good_f10 = 1.0;
+float good_f11 = -1.0;
+float good_f12 = - 1.0;
+float good_f13 = PI;
+float good_f14 = -PI;
+float good_f15 = - PI;
+
+string good_s00;
+string good_s01 = "ok";
+string good_s02 = L"L";
+string good_s03 = good_s01;
+string good_s04 = good_s00; // TODO: Should emit warning in LSO
+key good_k00;
+string good_s05 = good_k00; // TODO: Should emit warning in LSO
+key good_k01 = "ok";
+string good_s06 = good_k01;
+key good_k02 = L"L";
+key good_k03 = good_s00; // TODO: Should emit warning in LSO
+key good_k04 = good_s01;
+key good_k05 = good_k01;
+key good_k06 = good_k00; // TODO: Should emit warning in LSO
+
+vector good_v00;
+vector good_v01 = <0, 0, 0>;
+vector good_v02 = <-0.0, 0.0, 0.0>;
+vector good_v03 = <- 0.0, 1, -2>;
+
+list good_l00;
+list good_l01 = [];
+list good_l02 = [<1,2,3>,<-1,2,3>, -1, TRUE, -ALL_SIDES, PI, - PI];
+
+// Bad:
+
+integer bad_i01 = -TRUE;     // $[E10020]
+integer bad_i02 = -FALSE;    // $[E10020]
+integer bad_i03 = -ZERO_VECTOR;    // $[E10020]
+integer bad_i04 = -ZERO_ROTATION;  // $[E10020]
+integer bad_i05 = -EOF;      // $[E10020]
+integer bad_i06 = -good_i01; // $[E10020]
+integer bad_i07 = ~1;        // $[E10020]
+integer bad_i08 = 1 - 1;     // $[E10020]
+integer bad_i09 = -1 - 1;    // $[E10020]
+integer bad_i10 = 1 + -1;    // $[E10020]
+float bad_f01 = -good_i01;   // $[E10020]
+float bad_f02 = -good_f01;   // $[E10020]
+float bad_f03 = -TRUE;       // $[E10020]
+float bad_f04 = -good_f01;   // $[E10020]
+string bad_s01 = - "what?";  // $[E10020]
+vector bad_v01 = -<1,2,3>;   // $[E10020]
+list bad_l01 = [-TRUE];      // $[E10020]
+list bad_l02 = [-<1,1,1>];   // $[E10020]
+list bad_l03 = [1,[2,3],4];  // $[E10020] TODO: add "Lists can't contain lists"
+list bad_l04 = -[1];         // $[E10020] (dubious - E10002 would be more appropriate here)
+
+default{timer(){
+
+// Typecasts
+
+// Good
+(string)1;
+(string)-1;
+(string) - 1;
+(string) TRUE;
+(string) FALSE;
+(string) ALL_SIDES;
+(string)-ALL_SIDES;
+(string) - ALL_SIDES;
+(string)-1.0;
+(string) - 1.0;
+(string)"";
+(string)(-TRUE);
+(string)(-<0,0,0>);
+(string)good_i01;
+(string)[-TRUE, -<0,0,0>, ~1];
+
+// Bad
+(string)-TRUE;     // $[E10019]
+(string) - FALSE;  // $[E10019]
+(string)~1;        // $[E10019]
+(string)-<0,0,0>;  // $[E10019]
+(string)-good_i01; // $[E10019]
+(string)[-"nope"]; // $[E10002]
+
+// Use variables to avoid extra warnings
+good_i00; good_i01; good_i02; good_i03; good_i04;
+good_i05; good_i06; good_i07; good_i08; good_i09;
+
+good_f00; good_f01; good_f02; good_f03; good_f04;
+good_f05; good_f06; good_f07; good_f08; good_f09;
+good_f10; good_f11; good_f12; good_f13; good_f14;
+good_f15;
+
+good_s00; good_s01; good_s02; good_s03; good_s04;
+good_s05; good_s06;
+
+good_k00; good_k01; good_k02; good_k03; good_k04;
+good_k05; good_k06;
+
+good_v00; good_v01; good_v02; good_v03;
+
+good_l00; good_l01; good_l02;
+
+}}

--- a/test.sh
+++ b/test.sh
@@ -33,4 +33,5 @@ rm -f ./test.run.txt
 if [ $failed != . ] ; then
   cat ./test.total.txt
   rm -f ./test.total.txt
+  exit 1
 fi

--- a/values.cc
+++ b/values.cc
@@ -59,9 +59,31 @@ void LLScriptExpression::determine_value() {
    }
 }
 
+void LLScriptGlobalVariable::determine_value() {
+   // ensure the symbol receives the constant value
+   if ( get_child(1)->get_node_type() == NODE_SIMPLE_ASSIGNABLE )
+      ((LLScriptIdentifier *)get_child(0))->get_symbol()->set_constant_value(get_child(1)->get_constant_value());
+   else {
+      // assign a default value to the symbol
+      LLScriptConstant *value;
+      switch(get_child(0)->get_type()->get_itype()) {
+         case LST_INTEGER:       value = new LLScriptIntegerConstant(0); break;
+         case LST_FLOATINGPOINT: value = new LLScriptFloatConstant(0.0f); break;
+         case LST_KEY:           // fall through
+         case LST_STRING:        value = new LLScriptStringConstant(""); break;
+         case LST_VECTOR:        value = new LLScriptVectorConstant(0.f, 0.f, 0.f); break;
+         case LST_QUATERNION:    value = new LLScriptQuaternionConstant(0.f, 0.f, 0.f, 1.f); break;
+         case LST_LIST:          value = new LLScriptListConstant((LLScriptSimpleAssignable *)NULL); break;
+         default:                fprintf(stderr, "Impossible"); exit(EXIT_FAILURE);
+      }
+      ((LLScriptIdentifier *)get_child(0))->get_symbol()->set_constant_value(value);
+   }
+}
+
 void LLScriptSimpleAssignable::determine_value() {
-   if ( get_child(0) )
+   if ( get_child(0) ) {
       constant_value = get_child(0)->get_constant_value();
+   }
 }
 
 void LLScriptVectorConstant::determine_value() {
@@ -134,7 +156,7 @@ void LLScriptQuaternionConstant::determine_value() {
    }
 
    if ( cv < 4 ) // not enough children;
-   return;
+      return;
 
    value = new LLQuaternion( v[0], v[1], v[2], v[3] );
 


### PR DESCRIPTION
Hopefully fixes #6. Reduces the number of failing test cases in #17 to 1.

It reintroduces some `delete` statements that were commented out as a fix to #2, fixing the warnings by adding a virtual destructor to `LLASTNode`. Please check for regressions before merging.