### PR TITLE
Add warning for strings prefixed with L.

### DIFF
--- a/logger.cc
+++ b/logger.cc
@@ -307,4 +307,6 @@ const char *Logger::warning_messages[] = {
    "No default label in switch; that may cause the statement to misbehave.\n"
       "See: https://jira.phoenixviewer.com/browse/FIRE-17710",        // 20017
    "Duplicate case label.",                                           // 20018
+   "Prefixing a string with L will cause a double quote (\")\n"
+     "to be inserted at the beginning of the string.",                // 20019
 };

--- a/logger.hh
+++ b/logger.hh
@@ -106,6 +106,7 @@ enum ErrorCode {
     W_CONSTANT_SWITCH,                 // 20016
     W_SWITCH_NO_DEFAULT,               // 20017
     W_DUPLICATE_CASE,                  // 20018
+    W_L_STRING,                        // 20019
     W_LAST
 
 };

--- a/lslmini.l
+++ b/lslmini.l
@@ -100,7 +100,12 @@ FS			(f|F)
 {N}*"."{N}+({E})?{FS}?	{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
 {N}+"."{N}*({E})?{FS}?	{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
 
-L?\"(\\.|[^\\"])*\"	{ yylval->sval = parse_string(yytext); return(STRING_CONSTANT); }
+L\"(\\.|[^\\"])*\"	{
+		yylval->sval = parse_string(yytext);
+		ERROR( yylloc, W_L_STRING );
+		return(STRING_CONSTANT);
+	}
+\"(\\.|[^\\"])*\"	{ yylval->sval = parse_string(yytext); return(STRING_CONSTANT); }
 
 "++"				{ return(INC_OP); }
 "--"				{ return(DEC_OP); }

--- a/scripts/constants.lsl
+++ b/scripts/constants.lsl
@@ -19,5 +19,9 @@ default {
                = 2;
       PRIM_GLOW                    // $[E10024] invalid
                 = 2;
+
+      llOwnerSay(
+                 L"This is a long(?) string"   // $[E20019] Prepends a quote
+                                            );
    }
 }

--- a/scripts/globals.lsl
+++ b/scripts/globals.lsl
@@ -32,18 +32,18 @@ float good_f15 = - PI;
 
 string good_s00;
 string good_s01 = "ok";
-string good_s02 = L"L";
+string good_s02 = L"x";      // $[E20019] prepends quote, like "x
 string good_s03 = good_s01;
-string good_s04 = good_s00; // TODO: Should emit warning in LSO
+string good_s04 = good_s00;  // TODO: Should emit warning in LSO
 key good_k00;
-string good_s05 = good_k00; // TODO: Should emit warning in LSO
+string good_s05 = good_k00;  // TODO: Should emit warning in LSO
 key good_k01 = "ok";
 string good_s06 = good_k01;
-key good_k02 = L"L";
-key good_k03 = good_s00; // TODO: Should emit warning in LSO
+key good_k02 = L"x";         // $[E20019]
+key good_k03 = good_s00;     // TODO: Should emit warning in LSO
 key good_k04 = good_s01;
 key good_k05 = good_k01;
-key good_k06 = good_k00; // TODO: Should emit warning in LSO
+key good_k06 = good_k00;     // TODO: Should emit warning in LSO
 
 vector good_v00;
 vector good_v01 = <0, 0, 0>;


### PR DESCRIPTION
This is valid syntax:

```lsl
llOwnerSay(L"String with L prefix");
```

However, due to a bug in the parser, the initial double quote makes its way to the output, which is:

```
"String with L prefix
```

This PR adds a warning for that.