### PR TITLE
Add a more verbose error in case of adding F to a float without DP.

### DIFF
--- a/lslmini.l
+++ b/lslmini.l
@@ -96,9 +96,14 @@ FS			(f|F)
 		return(IDENTIFIER);
 	}
 
-{N}+{E}				{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
-{N}*"."{N}+({E})?{FS}?	{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
-{N}+"."{N}*({E})?{FS}?	{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
+{N}+{E}{FS}			{
+		yylval->fval = (F32)atof(yytext);
+		ERROR( yylloc, E_SYNTAX_ERROR, "F can't go after a float number without a decimal point." );
+		return(FP_CONSTANT);
+	}
+{N}+{E}						{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
+{N}*"."{N}+({E})?{FS}?		{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
+{N}+"."{N}*({E})?{FS}?		{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
 
 L\"(\\.|[^\\"])*\"	{
 		yylval->sval = parse_string(yytext);

--- a/scripts/constants.lsl
+++ b/scripts/constants.lsl
@@ -23,5 +23,19 @@ default {
       llOwnerSay(
                  L"This is a long(?) string"   // $[E20019] Prepends a quote
                                             );
+
+      1.0 + 1. + .1 +
+                      .      // $[E10019] Syntax error
+                         + 1.0E+01 + 1.e1 + .1e1;
+      00.e-1 + 1e1 + 1e+1 + 1e-1;
+
+      1.0f + 1.f + .1f +
+                         .f  // $[E10019]
+                            + 1.0E+01f + 1.e1f + .1e1f;
+      00.e-1f +
+                1e1f         // $[E10019] f is illegal if there's no period
+                     +
+                       1E+2f // $[E10019]
+                            ;
    }
 }


### PR DESCRIPTION
The LSL parser was originally modified from a C parser, as hinted by some of the things left behind. #23 is one, and this issue is another.

Floating-point numbers can end in `f`, which does nothing. But for some reason, they can only end in `f` if they have an explicit decimal point. So, `3.4f`, `.3f`, `3.0E+3f` are all valid, but `3E+3f` is not.

Typically, the lexer interprets that as `FP_CONSTANT` `IDENTIFIER` and the parser gives a syntax error. This commit adds a more verbose error and better error recovery in this situation, just in case people coming from C are used to adding the `f`.

Before:

```
ERROR:: (  5, 12): syntax error, unexpected IDENTIFIER
```

After:

```
ERROR:: (  5,  9): F can't go after a float number without a decimal point.
```