### PR TITLE
Fix a scope issue in switch statement.

### DIFF
--- a/lslmini.hh
+++ b/lslmini.hh
@@ -471,7 +471,7 @@ class LLScriptWhileStatement : public LLScriptStatement {
 class LLScriptSwitchStatement : public LLScriptStatement {
   public:
     LLScriptSwitchStatement( class LLScriptExpression *expression, class LLScriptStatement *body )
-      : LLScriptStatement(2, expression, body) {};
+      : LLScriptStatement(2, expression, body) { symbol_table = new LLScriptSymbolTable(); };
     virtual char *get_node_name() { return "switch"; };
     virtual LLNodeSubType get_node_sub_type() { return NODE_SWITCH_STATEMENT; };
     virtual void final_pre_checks();

--- a/scripts/switch/switch.lsl
+++ b/scripts/switch/switch.lsl
@@ -8,6 +8,7 @@ default
                  )
         {
             case i * 0 + 1:
+                integer j; j;
                 llOwnerSay("i is 1");
                 break;
             case 2 // unlike C, colon is not mandatory if a {} block follows


### PR DESCRIPTION
Declarations inside switch do not conflict with declarations out of it, because the switch converter adds braces around the whole thing. We needed to open a new scope for that reason.

(check test case before and after the patch to see the problem)