### PR TITLE
Allow // comments anywhere in builtins.txt; simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,9 @@ builtins_txt.cc: builtins.txt
 	echo "#pragma execution_character_set(\"utf-8\")" >> builtins_txt.cc
 	echo "#endif" >> builtins_txt.cc
 	echo "char *builtins_txt[] = {" >> builtins_txt.cc
-	cat builtins.txt | \
-		sed "1d" | \
-		sed "s/\"/\\\\\\\"/g" | \
-		sed "s/^/\"/g" | \
-		sed "s/$$/\",/g" >> builtins_txt.cc
+	sed -e '/^\/\//d; s/"/\\\"/g; s/^/"/; s/$/",/' \
+		builtins.txt >> builtins_txt.cc || \
+			{ rm -f builtins_txt.cc ; false ; }
 	echo "(char*)0 };" >> builtins_txt.cc
 
 lex.yy.o: lex.yy.c lslmini.tab.h


### PR DESCRIPTION
Removes lines that start with // at the very start of the line during sed processing, to allow for comments, as opposed to blindly deleting the first line.

Also merge the sed calls into one, use single instead of double quotes, and remove builtins_txt.cc in case sed fails, so that a subsequent 'make' invocation doesn't work on a bogus or incomplete builtins_txt.cc file.

It's a minor fix that hopefully will help people that want to use different builtins.