### PR TITLE
Fix several FIXMEs and bugs, simplify reports

### DIFF
--- a/logger.cc
+++ b/logger.cc
@@ -247,7 +247,7 @@ const char *Logger::error_messages[] = {
    "Invalid operator: %s %s %s.",                                     // 10002
    "`%s' is deprecated.",                                             // 10003
    "`%s' is deprecated, use %s instead.",                             // 10004
-   "Attempting to use `%s' as a %s, but it is a %s.",                 // 10005
+   "Attempting to use `%s' as a %s, but it is a%s %s.",               // 10005
    "`%s' is undeclared.",                                             // 10006
    "`%s' is undeclared; did you mean %s?",                            // 10007
    "Invalid member: `%s.%s'.",                                        // 10008
@@ -266,8 +266,8 @@ const char *Logger::error_messages[] = {
    "Expression and constant without operator.",                       // 10021
    "State must have at least one event handler.",                     // 10022
    "",                                                                // 10023
-   "`%s' is a constant and cannot be used as an lvalue.",             // 10024
-   "`%s' is a constant and cannot be used in a variable declaration.", // 10025
+   "",                                                                // 10024
+   "",                                                                // 10025
    "Not all code paths return a value.",                              // 10026
    "Declaring `%s' as parameter %d of `%s' which should be `%s %s'.", // 10027
    "Too many parameters for event `%s'.",                             // 10028

--- a/logger.hh
+++ b/logger.hh
@@ -70,8 +70,8 @@ enum ErrorCode {
     E_NO_OPERATOR,                     // 10021
     E_NO_EVENT_HANDLERS,               // 10022
     E_removed_1,                       // 10023
-    E_BUILTIN_LVALUE,                  // 10024
-    E_SHADOW_CONSTANT,                 // 10025
+    E_removed_2,                       // 10024
+    E_removed_3,                       // 10025
     E_NOT_ALL_PATHS_RETURN,            // 10026
     E_ARGUMENT_WRONG_TYPE_EVENT,       // 10027
     E_TOO_MANY_ARGUMENTS_EVENT,        // 10028

--- a/scripts/constants.lsl
+++ b/scripts/constants.lsl
@@ -1,23 +1,20 @@
 default {
    state_entry() {
+      integer x = PRIM_TEXTURE;
+      if (x == 17) 0;              // $[E20011] always true
+      integer y = PRIM_GLOW + PRIM_TEXTURE;
+      if (y == 42) 0;              // FIXME: should be $ [E20011] always true
       integer
-             x                     // $[E20009] unused
-               = PRIM_TEXTURE;
-      integer
-              y                    // $[E20009] unused
-                = PRIM_GLOW + PRIM_TEXTURE;
-      integer
-              // FIXME: should not emit E20009
-              PARCEL_DETAILS_DESC  // $[E20009] unused??, $[E10025] invalid
+              PARCEL_DETAILS_DESC  // $[E10005] invalid
                                  ;
       integer
-              // FIXME: should not emit E20009
-              PARCEL_DETAILS_NAME  // $[E20009] unused??, $[E10025] invalid
+              PARCEL_DETAILS_NAME  // $[E10005] invalid
                                   = 5;
+      if (PARCEL_DETAILS_NAME == 0) 0; // $[E20011] true (regression test)
 
       PRI_GLOW                     // $[E10006] undeclared
                = 2;
-      PRIM_GLOW                    // $[E10024] invalid
+      PRIM_GLOW                    // $[E10005] invalid
                 = 2;
 
       llOwnerSay(
@@ -37,5 +34,6 @@ default {
                      +
                        1E+2f // $[E10019]
                             ;
+
    }
 }

--- a/scripts/events.lsl
+++ b/scripts/events.lsl
@@ -38,17 +38,19 @@ default {
    }
    // FIXME: Wrong error location for E10028
    changed             // $[E10028] too many params
-          (integer changed
+          (integer
+                   changed           // $[E10005] it's an event name
                           ,          // Correct location for [E10028]
                             integer  // Acceptable location for [E10028]
                                     extra) {
    }
-   // FIXME: Should not emit E10006
-   foo                 // $[E10006] (undeclared)????, $[E10030] invalid event
+   foo                 // $[E10030] invalid event
       () {
    }
-   // FIXME: Should not emit E10006
-   bar                 // $[E10006] (undeclared)????, $[E10030] invalid event
+   bar                 // $[E10030] invalid event
       (integer baz) {
+   }
+   TEXTURE_BLANK       // $[E10030] $[E10005] attempt to use as event but it's constant (FIXME: error message can be improved)
+                (integer x) {
    }
 }

--- a/symtab.hh
+++ b/symtab.hh
@@ -34,6 +34,7 @@ class LLScriptSymbol {
         case SYM_FUNCTION:  return "function";
         case SYM_STATE:     return "state";
         case SYM_LABEL:     return "label";
+        case SYM_EVENT:     return "event";
         case SYM_ANY:       return "any";
         default:            return "invalid";
       }

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,8 @@ for f in scripts/*.lsl scripts/*/*.lsl ; do
     ./lslint -F -\# -A "$f" > ./test.run.txt 2>&1
   elif [ "${f#scripts/lz_overr/}" != "$f" ] ; then
     ./lslint -zF -\# -A "$f" > ./test.run.txt 2>&1
+  elif [ "${f#scripts/todo/}" != "$f" ] ; then
+    true # skip these tests
   else
     # test in both mono and lso modes
     ./lslint -m -\# -A "$f" > ./test.run.txt 2>&1 \


### PR DESCRIPTION
- Declaring an event with a wrong event name does no longer report Undeclared identifier (E10006).
- Changed messages E10024 and E10025 to the more generic E10002.
  E10024:  Before: <code>"\`\<name>' is a constant and cannot be used as an lvalue."</code>
            After: <code>"Attempting to use \`\<name>' as a variable, but it is a constant."</code>
  E10025:  Before: <code>"\`\<name>' is a constant and cannot be used in a variable declaration."</code>
            After: <code>"Attempting to use \`\<name>' as a variable, but it is a constant."</code>
- Don't allow changing the values of the constants locally.
- Don't give unused variable errors when declaring a variable with the name of a built-in constant.
- Give an error when using an event name as a variable name.
- Add a `scripts/todo/` directory to test.sh, which does nothing and is intended for keeping track of tests to be implemented in future, but that don't currently work properly.

The second point can be controversial. It is doing it wrong in at least one corner case: using a built-in constant in place of an event name. The message is:

```
ERROR:: ( 53,  4): Attempting to use `TEXTURE_BLANK' as a event, but it is a variable.
```

Fortunately, that one is accompanied by:

```
ERROR:: ( 53,  4): `TEXTURE_BLANK' is not a valid event name.
```

Is that acceptable?