### PR TITLE
Add print support with warning.

### DIFF
--- a/logger.cc
+++ b/logger.cc
@@ -309,4 +309,5 @@ const char *Logger::warning_messages[] = {
    "Duplicate case label.",                                           // 20018
    "Prefixing a string with L will cause a double quote (\")\n"
      "to be inserted at the beginning of the string.",                // 20019
+   "print does nothing. Attempting to use the result %s.\n",     // 20020
 };

--- a/logger.hh
+++ b/logger.hh
@@ -107,6 +107,7 @@ enum ErrorCode {
     W_SWITCH_NO_DEFAULT,               // 20017
     W_DUPLICATE_CASE,                  // 20018
     W_L_STRING,                        // 20019
+    W_PRINT,                           // 20020
     W_LAST
 
 };

--- a/lslmini.l
+++ b/lslmini.l
@@ -76,6 +76,7 @@ FS			(f|F)
 "for"				{ return(FOR); }
 "do"				{ return(DO); }
 "while"				{ return(WHILE); }
+"print"				{ return(PRINT); }
 
 "."					{ return(PERIOD); }
 

--- a/lslmini.y
+++ b/lslmini.y
@@ -996,7 +996,14 @@ unarypostfixexpression
 	}
 	| PRINT '(' expression ')'
 	{
-		/* FIXME: What does this do? */
+		if (mono_mode)
+			ERROR( &@1, W_PRINT, "will cause the compilation to fail");
+		else
+			ERROR( &@1, W_PRINT, "may cause a runtime error");
+		// Result is the same type as the expression, but without a
+		// value. As a compromise, we return the expression because
+		// we can't fetch the type at this point.
+		$$ = $3;
 	}
 	| constant
 	{

--- a/scripts/print.lsl
+++ b/scripts/print.lsl
@@ -1,0 +1,14 @@
+default{timer(){
+
+    print("yay");                // $[E20020] print does nothing
+    print(3);                    // $[E20020]
+    print(<4,5,6>);              // $[E20020]
+
+    string s = print("yay");     // $[E20020]
+    integer i = print(3);        // $[E20020]
+    vector v = print(<4,5,6>);   // $[E20020]
+
+    s = print(<4,5,6>);          // $[E20020] $[E10002] string = vector invalid
+
+    s; i; v; // avoid E20009
+}}


### PR DESCRIPTION
`print` is a reserved word that can't be used for user identifiers; the lexer should return it but it was accidentally removed together with the events when they were moved out of the lexer into `builtins.txt`.

`print` is obsolete and has no use. The wiki seems to imply that it outputs to the server's `stdout`; see http://wiki.secondlife.com/wiki/Print but I doubt that's the case any longer. In any case, it has no user-visible effect, and it is a potential cause of problems (the result type is the same as the contained expression, but trying to use it results in disaster most of the time), so the wisest thing to do is to warn the user about that.