### PR TITLE
Give error when a declaration is in an if, while, for, or do without braces

### DIFF
--- a/logger.cc
+++ b/logger.cc
@@ -278,6 +278,7 @@ const char *Logger::error_messages[] = {
    "break statement must be inside a switch statement.",              // 10033
    "Multiple default labels for switch statement.",                   // 10034
    "Case type incompatible with switch type.",                        // 10035
+   "Declaration needs braces {}."                                     // 10036
 
 };
 

--- a/logger.hh
+++ b/logger.hh
@@ -82,6 +82,7 @@ enum ErrorCode {
     E_BREAK_WITHOUT_SWITCH,            // 10033
     E_SWITCH_MULTIPLE_DEFAULTS,        // 10034
     E_INCOMPATIBLE_CASE_TYPE,          // 10035
+    E_DECLARATION_NOT_ALLOWED,         // 10036
     E_LAST
 
 

--- a/lslmini.cc
+++ b/lslmini.cc
@@ -217,6 +217,12 @@ void LLASTNode::define_symbols() {
 }
 
 void LLScriptDeclaration::define_symbols() {
+   LLNodeSubType type = get_parent()->get_node_sub_type();
+   if (   type == NODE_IF_STATEMENT || type == NODE_FOR_STATEMENT
+       || type == NODE_DO_STATEMENT || type == NODE_WHILE_STATEMENT) {
+      ERROR( HERE, E_DECLARATION_NOT_ALLOWED );
+      return;
+   }
    LLScriptIdentifier *identifier = (LLScriptIdentifier *)get_children();
    identifier->set_symbol( new LLScriptSymbol(identifier->get_name(), identifier->get_type(), SYM_VARIABLE, SYM_LOCAL, identifier->get_lloc()) );
    define_symbol(identifier->get_symbol());

--- a/scripts/scope3.lsl
+++ b/scripts/scope3.lsl
@@ -4,5 +4,6 @@ default {
         integer test = 1; // works fine
         test();
         test = 2;
+        if (llGetAttached()) integer test; // $[E10036], but no E10001
     }
 }


### PR DESCRIPTION
It's not allowed by the compiler, so it should not be allowed by lslint.

Examples:

These fail:

```lsl
    while (1)
        string s;

    do
        integer i;
    while (1);

    for (; 1; )
        float f;

    if (i)
        key k;
    else
        list L;
```

These work:

```lsl
    while (1)
        {string s;}

    do {
        integer i;
    } while (1);

    for (; 1; )
    {
        float f;
    }

    if (i) {
        key k;
    } else {
        list L;
    }
```
