### PR TITLE
\t stands for 4 spaces.

### DIFF
--- a/lslmini.l
+++ b/lslmini.l
@@ -163,14 +163,19 @@ L\"(\\.|[^\\"])*\"	{
 %%
 
 char *parse_string(char *input) {
-	char *str = new char[strlen(input) + 1 - 2];
+	char *str = new char[(strlen(input) - 2) * 2 + 1];
 	char *yp  = input + 1;
 	char *sp  = str;
 	while ( *yp ) {
 		if ( *yp == '\\' ) {
 			switch ( *++yp ) { 
 					case 'n':  *sp++ = '\n'; break;
-					case 't':  *sp++ = '\t'; break; // TODO: should this be \t or 4 spaces?
+					case 't':
+						*sp++ = ' ';
+						*sp++ = ' ';
+						*sp++ = ' ';
+						*sp++ = ' ';
+						break;
 					case '\\': *sp++ = '\\'; break;
 					case '"':  *sp++ = '"';  break;
 					default:   *sp++ = '\\'; *sp++ = *yp; break;

--- a/scripts/constants.lsl
+++ b/scripts/constants.lsl
@@ -48,5 +48,7 @@ default {
       if ((key)"AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA") 0; // TODO, should be [E20011] true
       if ([]) 0;                  // $[E20012] false
       if (["", ""]) 0;            // $[E20011] true
+
+      if ("\t\t\t\t\t\t" == "                        ") 0; // $[E20011] true
    }
 }


### PR DESCRIPTION
This commit is somewhat wasteful in that it reserves space as if the whole string was made of \t, but that's the worst case and has to be contemplated. The alternative is to make two passes over the string, one to calculate the final size and another to extract the characters. We've chosen the easy way.