### PR TITLE
Allow state changes where they are really allowed, and fix messages.

### DIFF
--- a/scripts/lso/error1.lsl
+++ b/scripts/lso/error1.lsl
@@ -8,6 +8,12 @@ string unused()  {                  // unused, not all code paths return values 
         state default;              // warning: hack that corrupts stack        $[E20004]
         return;                     // error: returning nothing in int function $[E10018]
     }
+    if (1 == 1) {                   // always true                              $[E20011]
+        state default;              // error: can't change state in function    $[E10014]
+    } else ;
+    while (1) {
+        state default;              // warning: hack that corrupts stack        $[E20004]
+    }
 }
 
 string test(integer a, vector v) {  // param a is never used                    $[E20009]

--- a/scripts/mono/error1.lsl
+++ b/scripts/mono/error1.lsl
@@ -1,0 +1,49 @@
+integer number = 2+2;               // non constant                             $[E10020]
+integer number = 3;                 // will only pass because above fails       $[E20009]
+integer number = 4;                 // already declared                         $[E10001]
+
+string unused()  {                  // unused, not all code paths return values $[E20009] $[E10026]
+    state default;                  // error: can't change state in function    $[E10014]
+    if (1 == 1) {                   // always true                              $[E20011]
+        state default;              // warning: hack with unintended effects    $[E20005]
+        return;                     // error: returning nothing in int function $[E10018]
+    }
+    if (1 == 1) {                   // always true                              $[E20011]
+        state default;              // error: can't change state in function    $[E10014]
+    } else ;
+    while (1) {
+        state default;              // warning: hack with unintended effects    $[E20005]
+    }
+}
+
+string test(integer a, vector v) {  // param a is never used                    $[E20009]
+    string q;                       // warning: declared but never used         $[E20009]
+    return v;                       // error: return vector in string function  $[E10018]
+}
+
+default {
+
+    state_entry(integer param) {    // state_entry does not take params         $[E10028]
+        integer number = "hello";   // type mismatch, warning: shadow decl      $[E10015] $[E20001]
+        int q;                      // should point out int->integer typo maybe $[E10019]
+        number = number-2;          // no longer error (was IDENTIFER INTEGER)  (E10021)
+        number = 2-2;               // no longer warning (was 2-2 = 2)          (E20008)
+        [1] == [2];                 // warning: only compares length            $[E20010]
+        number = number;            // warning: statement with no effect?
+        str = "hi!";                // undeclared                               $[E10006]
+        llSay(0, number.x);         // number is not a vector                   $[E10010]
+        LLsay(0, llListToString([])); // typos; suggest llSay, llList2String    $[E10007] $[E10007]
+        test(1, "hi");              // arg 2 should be vector not string        $[E10011]
+        jump number;                // number is not a label                    $[E10005]
+        return number;              // returning a value in an event            $[E10017]
+        state default;              // warning: state current acts like return  $[E20003]
+                                    // warning: code is never reached?
+    }
+
+    touch_start() {                 // requires parameters                      $[E10029]
+    }
+
+    at_target(integer i, vector v, string s) { // third param should be vector  $[E10027]
+    }
+
+}


### PR DESCRIPTION
They have different effects for Mono and LSO, because in Mono the stack can't be corrupted. Also, state changes are DISallowed when the 'if' has an 'else', but are allowed in a 'while', 'do' or 'for' too.

Separate the test case for this into LSO and Mono. There was no test in the suite for E20005 anyway.