### PR TITLE
Add flag for expected errors/warnings (default on).

### DIFF
--- a/logger.hh
+++ b/logger.hh
@@ -114,6 +114,12 @@ enum ErrorCode {
 
 };
 
+enum AssertType {
+    NO_ASSERTIONS,
+    EXPECTED_ASSERTIONS,
+    ALL_ASSERTIONS
+};
+
 #define LOG         Logger::get()->log
 #define LOGV        Logger::get()->logv
 #define IN(v)       (v)->get_lloc()
@@ -159,7 +165,7 @@ class Logger {
     void    set_show_info(bool v){ show_info = v;}
     void    set_sort(bool v)     { sort = v;     }
     void    set_show_error_codes(bool v) { show_error_codes = v; }
-    void    set_check_assertions(bool v) { check_assertions = v; }
+    void    set_check_assertions(AssertType v) { check_assertions = v; }
     void    set_file_path(const char *v) { file_path = v; }
 
     void    add_assertion( int line, ErrorCode error ) {
@@ -167,14 +173,14 @@ class Logger {
     }
 
   protected:
-    Logger() : errors(0), warnings(0), show_end(false), show_info(false), sort(true), show_error_codes(false), check_assertions(false), file_path(NULL), last_message(NULL), file(stderr) {};
+    Logger() : errors(0), warnings(0), show_end(false), show_info(false), sort(true), show_error_codes(false), check_assertions(NO_ASSERTIONS), file_path(NULL), last_message(NULL), file(stderr) {};
     int     errors;
     int     warnings;
     bool    show_end;
     bool    show_info;
     bool    sort;
     bool    show_error_codes;
-    bool    check_assertions;
+    AssertType check_assertions;
     const char *file_path;
     class LogMessage *last_message;
 

--- a/lslmini.cc
+++ b/lslmini.cc
@@ -833,6 +833,7 @@ void usage(char *name) {
    printf("\t-S\t\tDon't sort log messages\n");
    printf("\t-#\t\tShow error codes (for debugging/testing)\n");
    printf("\t-A\t\tCheck error assertions (for debugging/testing)\n");
+   printf("\t-a\t\tFlag: Don't report marked warnings/errors (default on)\n");
    printf("\t-i\t\tFlag: Ignore preprocessor directives (default off)\n");
    printf("\t-u\t\tFlag: Warn about unused event parameters (default off)\n");
    printf("\t-w\t\tFlag: Enable switch statements (default off)\n");
@@ -905,6 +906,8 @@ int main(int argc, char **argv) {
    void *scanner;
    Logger *logger = Logger::get();
 
+   logger->set_check_assertions(EXPECTED_ASSERTIONS);
+
 #ifdef COMPILE_ENABLED
    bool compile   = true;
 #endif
@@ -940,7 +943,13 @@ int main(int argc, char **argv) {
                case 'v': logger->set_show_info(true); break;
                case 'S': logger->set_sort(false);     break;
                case '#': logger->set_show_error_codes(true); break;
-               case 'A': logger->set_check_assertions(true); break;
+               case 'A': logger->set_check_assertions(ALL_ASSERTIONS); break;
+               case 'a':
+                  if (argv[i][j+1] == '-') {
+                     logger->set_check_assertions(NO_ASSERTIONS);
+                     j++;
+                  } else logger->set_check_assertions(EXPECTED_ASSERTIONS);
+                  break;
                case 'p': print_path = true; break;
                case 'V': version(); return 0;
                case 'i':


### PR DESCRIPTION
The new -a flag enables assertions to just remove expected messages. It defaults to on, so this is a behaviour change. Using -a- enables old behaviour.

Example script:

```lsl
myfunc(string s) // $[E20009] $[E20009]
{
}

default{timer(){

llOwnerSay(L"a b", c); // $[E10012] $[E20019] $[E10005]
d; // $[E10006]

}}
```

Invoking old behaviour, using `-#` to display error codes:

```
$ lslint -# -a- testcase.lsl
ERROR:: (  7,  1): [E10012] Too many arguments to function `llOwnerSay'.
ERROR:: (  7, 20): [E10006] `c' is undeclared.
ERROR:: (  8,  1): [E10006] `d' is undeclared.
 WARN:: (  1,  1): [E20009] function `myfunc' declared but never used.
 WARN:: (  1, 15): [E20009] variable `s' declared but never used.
 WARN:: (  7, 12): [E20019] Prefixing a string with L will cause a double quote (")
                    to be inserted at the beginning of the string.
TOTAL:: Errors: 3  Warnings: 3
```

Note that the error in `(7, 20)` has been deliberately misspelled.

New behaviour:

```
$ lslint -# testcase.lsl
ERROR:: (  7, 20): [E10006] `c' is undeclared.
TOTAL:: Errors: 1  Warnings: 0
```

Note the need of two `$[E20009]` in line 1, one for the function and another for the variable. This addresses #48 as well.

For comparison, here's what the `-A` flag does:

```
$ lslint -# -A testcase.lsl
ERROR:: Assertion failed: error 10005 on line 7.
ERROR:: (  7, 20): Unexpected error: [E10006] `c' is undeclared.
TOTAL:: Errors: 2  Warnings: 0
```

This addresses #40 and the concern in #48.