### PR TITLE
Report correct column in UTF-8 source programs.

### DIFF
--- a/lslmini.l
+++ b/lslmini.l
@@ -162,6 +162,7 @@ L?\"(\\.|[^\\"])*\"	{
 
 
 \n					{ LLOC_LINES(1); LLOC_STEP(); }
+[\x80-\xBF]			{ yylloc->last_column--; }
 .					{ LLOC_STEP(); /* ignore bad characters */ }
 
 %%


### PR DESCRIPTION
LSL ignores a bunch of characters in the source: `$`, `'`, \`, `\`, `?`, `#`, control characters including DEL, and UTF-8 characters with a Unicode codepoint >= U+0080.

When such a character is present in a line outside a string, it is ignored as if it was a space. But the column counter counts bytes, therefore it doesn't count right when the characters are UTF-8 multibyte characters.

Example:

```lsl
key »k« = ;
```

reports:

```
ERROR:: (  1, 13): syntax error, unexpected ';'
```

and the column is out of range. With this patch it reports:

```
ERROR:: (  1, 11): syntax error, unexpected ';'
```

which is the column where the `;` is.