### PR TITLE
Fix issues related to `lazy_list_set`

### DIFF
--- a/lslmini.cc
+++ b/lslmini.cc
@@ -1064,7 +1064,9 @@ nextarg:
          dec->push_child(new LLScriptIdentifier(LLScriptType::get(LST_LIST), "inputlist"));
          dec->push_child(new LLScriptIdentifier(LLScriptType::get(LST_INTEGER), "index"));
          dec->push_child(new LLScriptIdentifier(LLScriptType::get(LST_LIST), "value"));
-         script->define_symbol(new LLScriptSymbol(name, LLScriptType::get(LST_LIST), SYM_FUNCTION, SYM_GLOBAL, dec));
+         LLScriptSymbol *sym = new LLScriptSymbol(name, LLScriptType::get(LST_LIST), SYM_FUNCTION, SYM_GLOBAL, dec);
+         script->define_symbol(sym);
+         sym->add_reference();
       }
 
       LOG(LOG_INFO, NULL, "Script parsed, collecting symbols");

--- a/lslmini.cc
+++ b/lslmini.cc
@@ -160,7 +160,11 @@ void LLASTNode::define_symbol(LLScriptSymbol *symbol) {
       shadow = symbol_table->lookup( symbol->get_name() );
 
       // Override?
-      if ( override_fn && shadow && shadow->get_symbol_type() == SYM_FUNCTION && shadow->get_sub_type() != SYM_BUILTIN ) {
+      if ( shadow  // warning: testing shadow first is important
+           && (override_fn
+               || (lazy_lists && !strcmp(shadow->get_name(), "lazy_list_set")))
+           && shadow->get_symbol_type() == SYM_FUNCTION
+           && shadow->get_sub_type() != SYM_BUILTIN ) {
          script->get_symbol_table()->remove(shadow);
          delete shadow;
          shadow = NULL;

--- a/scripts/lazylist/lazy1.lsl
+++ b/scripts/lazylist/lazy1.lsl
@@ -1,0 +1,2 @@
+// Should not emit unused function warning (or any warning)
+default{timer(){}}

--- a/scripts/lazylist/lazy2.lsl
+++ b/scripts/lazylist/lazy2.lsl
@@ -1,0 +1,8 @@
+list
+     lazy_list_set  // $[E20009] declared but never used
+                  (list target, integer index, list element)
+{
+    return llListReplaceList(target, element, index, index);
+}
+
+default{timer(){}}

--- a/scripts/lazylist/lazy3.lsl
+++ b/scripts/lazylist/lazy3.lsl
@@ -1,0 +1,11 @@
+list lazy_list_set(list target, integer index, list element)
+{
+    return llListReplaceList(target, element, index, index);
+}
+
+default{timer(){
+
+    list a;
+    a[0] = "";  // implicitly references lazy_list_set so no warning emitted
+
+}}

--- a/scripts/lazylist/lazy4.lsl
+++ b/scripts/lazylist/lazy4.lsl
@@ -1,0 +1,27 @@
+// Check whether order alters outcome
+// Check multiple definitions
+// Check overriding of a function other than lazy_list_set
+
+x()
+{
+    list a;
+    a[0] = "";
+}
+
+list lazy_list_set(list target, integer index, list element)
+{
+    return llListReplaceList(target, element, index, index);
+}
+
+list lazy_list_set(list target, integer index, list element)
+{
+    return llListReplaceList(target, element, index, index);
+}
+
+x(){}  // $[E10001] Duplicate identifier
+
+default{timer(){
+
+    x();
+
+}}

--- a/scripts/lazylist/lazy5.lsl
+++ b/scripts/lazylist/lazy5.lsl
@@ -1,0 +1,17 @@
+x(){
+  list a;
+  a[0] = "";  // $[E10011] Passing integer as argument 2 (invalid arg list)
+}
+
+list lazy_list_set(list target, list element, integer index)
+{
+    return llListReplaceList(target, element, index, index);
+}
+
+default{timer(){
+
+    list a;
+    a[0] = "";  // $[E10011] 
+    x();
+
+}}

--- a/symtab.hh
+++ b/symtab.hh
@@ -15,7 +15,9 @@ class LLScriptSymbol {
 
     LLScriptSymbol( char *name, class LLScriptType *type, LLSymbolType symbol_type, LLSymbolSubType sub_type, class LLScriptFunctionDec *function_decl = NULL )
       : name(name), type(type), symbol_type(symbol_type), sub_type(sub_type), function_decl(function_decl),
-      constant_value(NULL), references(0), assignments(0), cur_references(0) {};
+      constant_value(NULL), references(0), assignments(0), cur_references(0) {
+          lloc = {0,0,0,0};
+    };
 
 
     char                *get_name()         { return name; }


### PR DESCRIPTION
Fix #56 by adding a reference to the function instead of the lazy addition proposed there.

Also, rather than defining it only if it does not exist previously, we make it act as if function override (flag `-F`) is in use, only in case that lazy lists are active and the function name is `lazy_list_set`. This makes the patch shorter and perhaps somewhat cleaner.

Fixed also another minor problem where if an error was ever reported against the default `lazy_list_set`, the line and column number were uninitialized. Now they are reported as (0, 0) always. Hopefully no errors should be generated any longer, but if they are, at least now the position is sane.