### PR TITLE
Fix some error locations.

### DIFF
--- a/final_walk.cc
+++ b/final_walk.cc
@@ -155,7 +155,7 @@ void LLScriptEventHandler::final_pre_checks() {
       while ( declared_param_id != NULL && passed_param_id != NULL ) {
          if ( !passed_param_id->get_type()->can_coerce(
                   declared_param_id->get_type()) ) {
-            ERROR( HERE, E_ARGUMENT_WRONG_TYPE_EVENT,
+            ERROR( IN(passed_param_id), E_ARGUMENT_WRONG_TYPE_EVENT,
                   passed_param_id->get_type()->get_node_name(),
                   param_num,
                   id->get_name(),
@@ -171,7 +171,7 @@ void LLScriptEventHandler::final_pre_checks() {
 
       if ( passed_param_id != NULL ) {
          // printf("too many, extra is %s\n", passed_param_id->get_name());
-         ERROR( HERE, E_TOO_MANY_ARGUMENTS_EVENT, id->get_name() );
+         ERROR( IN(passed_param_id), E_TOO_MANY_ARGUMENTS_EVENT, id->get_name() );
       } else if ( declared_param_id != NULL ) {
          // printf("too few, extra is %s\n", declared_param_id->get_name());
          ERROR( HERE, E_TOO_FEW_ARGUMENTS_EVENT, id->get_name() );

--- a/lslmini.cc
+++ b/lslmini.cc
@@ -609,7 +609,7 @@ void LLScriptFunctionExpression::determine_type() {
    while ( declared_param_id != NULL && passed_param_id != NULL ) {
       if ( !passed_param_id->get_type()->can_coerce(
                declared_param_id->get_type()) ) {
-         ERROR( HERE, E_ARGUMENT_WRONG_TYPE,
+         ERROR( IN(passed_param_id), E_ARGUMENT_WRONG_TYPE,
                passed_param_id->get_type()->get_node_name(),
                param_num,
                id->get_name(),
@@ -624,7 +624,7 @@ void LLScriptFunctionExpression::determine_type() {
    }
 
    if ( passed_param_id != NULL ) {
-      ERROR( HERE, E_TOO_MANY_ARGUMENTS, id->get_name() );
+      ERROR( IN(passed_param_id), E_TOO_MANY_ARGUMENTS, id->get_name() );
    } else if ( declared_param_id != NULL ) {
       ERROR( HERE, E_TOO_FEW_ARGUMENTS, id->get_name() );
    }

--- a/scripts/events.lsl
+++ b/scripts/events.lsl
@@ -9,40 +9,49 @@ state_entry            // $[E10031] can't be used as function name
 
 default {
    state_entry() {
-      // FIXME: Wrong error location
-      boy              // $[E10011] wrong arg type (integer vs string)
-         (
-          "foo"        // Should be here: [E10011] wrong arg type
+      boy(
+          "foo"        // $[E10011] wrong arg type (integer vs string)
                );
+      boy(1,
+             "foo"     // $[E10012] too many arguments
+                  );
+
+      boy              // $[E10013] too few arguments
+         (
+          )            // Ideal location for E10013 above
+           ;
    }
    on_rez(integer paramie) {
    }
-   // FIXME: Wrong error location for E10027
-   on_rez              // $[E10032] multiple handlers, $[E10027] wrong type
+   // TODO: Improve error location for E10027
+   on_rez              // $[E10032] multiple handlers
          (
           string       // Should be here: [E10027] wrong parameter type
-                 paramie) {
+                 paramie   // Reported here: $[E10027] wrong parameter type
+                        ) {
    }
-   // FIXME: Wrong error location for E10027
-   object_rez          // $[E10027] wrong type
+   // TODO: Improve error location for E10027
+   object_rez
              (
               float    // Should be here: [E10027] wrong parameter type
-                    s) {
+                    s  // Reported here: $[E10027] wrong parameter type
+                     ) {
    }
-   // FIXME: Wrong error location for E10029
+   // TODO: Improve error location for E10028
+   changed
+          (integer
+                   changed           // $[E10005] it's an event name
+                          ,          // Correct location for [E10028]
+                            integer  // Acceptable location for [E10028]
+                                    extra  // $[E10028] too many params
+                                         ) {
+   }
+   // TODO: Improve error location for E10029
    listen              // $[E10029] too few params
          (integer
                   channel    // Acceptable location for [E10029]
                          )   // Correct location for [E10029]
                            {
-   }
-   // FIXME: Wrong error location for E10028
-   changed             // $[E10028] too many params
-          (integer
-                   changed           // $[E10005] it's an event name
-                          ,          // Correct location for [E10028]
-                            integer  // Acceptable location for [E10028]
-                                    extra) {
    }
    foo                 // $[E10030] invalid event
       () {


### PR DESCRIPTION
Gets rid of some FIXMEs in the test suite, but since we lack information on the location of some tokens, a few of the FIXMEs have been replaced by TODOs for future enhancement, when that information is provided.

See https://github.com/Sei-Lisa/lslint/blob/29eb1016b265ae9f25e901a364109494e3f2286a/scripts/events.lsl for an overview of the changes.
