### PR TITLE
Improve recovery from syntax errors

### DIFF
--- a/lslmini.y
+++ b/lslmini.y
@@ -667,6 +667,10 @@ declaration
 		DEBUG( LOG_DEBUG_SPAM, NULL, "= %s\n", $4->get_node_name());
 		$$ = new LLScriptDeclaration(new LLScriptIdentifier($1, $2, &@2), $4);
 	}
+	| typename IDENTIFIER '=' error
+	{
+		$$ = new LLScriptDeclaration(new LLScriptIdentifier($1, $2, &@2), NULL);
+	}
 	;
 
 forexpressionlist

--- a/lslmini.y
+++ b/lslmini.y
@@ -250,6 +250,10 @@ globals
 			$$ = $2;
 		}
 	}
+	| error ';'
+	{
+		$$ = NULL;
+	}
 	;
 
 global

--- a/lslmini.y
+++ b/lslmini.y
@@ -285,9 +285,9 @@ global_variable
 			$$ = NULL;
 		}
 	}
-	| name_type '=' error ';'
+	| name_type error ';'
 	{
-		$$ = NULL;
+		$$ = new LLScriptGlobalVariable($1, NULL);
 	}
 	;
 
@@ -511,6 +511,10 @@ compound_statement
 	{
 		$$ = new LLScriptStatement(0);
 	}
+	| '{' statements error '}'
+	{
+		$$ = new LLScriptCompoundStatement($2);
+	}
 	;
 
 statements
@@ -603,6 +607,10 @@ statement
 	| BREAK ';'
 	{
 		$$ = new LLScriptBreakStatement();
+	}
+	| declaration error ';'
+	{
+		$$ = $1;
 	}
 	| error ';'
 	{


### PR DESCRIPTION
Variables still get declared even if there's a syntax error in the declaration's assignment part.

The case of a missing semicolon at the end of a compound statement is also more gracefully handled now.

Fixes #59.