### PR TITLE
Follow-up to 618bbe8 to fix compilation errors.

### DIFF
--- a/builtins.cc
+++ b/builtins.cc
@@ -5,7 +5,7 @@
 #include "logger.hh"
 
 char *builtins_file = NULL;
-extern char *builtins_txt[];
+extern const char *builtins_txt[];
 
 struct _TypeMap {
    const char *name;


### PR DESCRIPTION
We forgot one 'const', which breaks compilation under Windows.