### PR TITLE
Fix violations of C++98

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 
 ifndef WINDOWS
 OPTIMIZE ?= 
-CXX = g++ -std=c++11 -g -Wall -pedantic -fno-omit-frame-pointer -ffloat-store
+CXX = g++ -g -Wall -std=c++98 -pedantic-errors -fno-omit-frame-pointer -ffloat-store
 CXXOUTPUT = -o
 ifndef MAC
 LD = g++ -g -static

--- a/ast.hh
+++ b/ast.hh
@@ -24,6 +24,7 @@ enum LLNodeType {
   NODE_STATEMENT,
   NODE_EXPRESSION,
 
+  NODE_LAST
 };
 
 // Node Sub-types

--- a/logger.hh
+++ b/logger.hh
@@ -31,6 +31,8 @@ enum LogLevel {
   LOG_DEBUG_MINOR,      // minor debug messages
   LOG_DEBUG_SPAM,       // spammy debug messages
   LOG_CONTINUE,         // continuation of last message
+
+  LOG_LAST
 };
 
 enum ErrorCode {
@@ -209,7 +211,7 @@ class LogMessage {
 
   private:
     LogLevel            type;
-    
+
     // we need our own copy of loc, because messages logged in the parser will be
     // handing us a copy of a loc structure that is constantly changing, and will
     // be invalid when we go to sort.

--- a/symtab.hh
+++ b/symtab.hh
@@ -16,7 +16,8 @@ class LLScriptSymbol {
     LLScriptSymbol( const char *name, class LLScriptType *type, LLSymbolType symbol_type, LLSymbolSubType sub_type, class LLScriptFunctionDec *function_decl = NULL )
       : name(name), type(type), symbol_type(symbol_type), sub_type(sub_type), function_decl(function_decl),
       constant_value(NULL), references(0), assignments(0), cur_references(0) {
-          lloc = {0,0,0,0};
+          static const YYLTYPE zero_lloc = {};
+          lloc = zero_lloc;
     };
 
 

--- a/types.hh
+++ b/types.hh
@@ -15,6 +15,8 @@ enum LST_TYPE {
   LST_VECTOR        = 5,
   LST_QUATERNION    = 6,
   LST_LIST          = 7,    // ??
+
+  LST_LAST
 };
 
 class LLScriptType : public LLASTNode {


### PR DESCRIPTION
Under Linux, use the -std=c++98 and the -pedantic-errors flags of GNU C++ so that violations of the older standard are visible. This should fix builds in older compilers as well.

There were several places where the enums ended in a comma. I've fixed that by adding `xxx_LAST` enum constants to these places, so that it's still possible to add new values without changing the line above to add the comma.

Quoting @XenHat in #56:

> I would recommend keeping the C++11 version, and adding a WINXP preprocessor thing.. to wrap the C++03 code around

I don't think it was worth doing that. I've found a way to make it compatible with the older standard without a big loss in readability. Adding preprocessor conditionals to select one compilation mode or the other would have been worse IMO. Unless new code is added that greatly benefits from the use of C++11 features, I think it's worth keeping full C++98 compatibility in the code, because the cost is quite low.

Edit: Sorry, it's C++98, not 99. I confused it with the C99 standard.