### PR TITLE
Fix another violation of a standard.

### DIFF
--- a/logger.hh
+++ b/logger.hh
@@ -140,11 +140,7 @@ enum AssertType {
 #ifdef DEBUG_LEVEL
 #define DEBUG LOG
 #else /* not DEBUG_LEVEL */
-#ifdef __GNUC__
-#define DEBUG(args...)
-#else /* not __GNUC__ */
-#define DEBUG(...)
-#endif /* not __GNUC__ */
+static inline void DEBUG(...) { }
 #endif /* not DEBUG_LEVEL */
 #endif /* not _MSC_VER */
 


### PR DESCRIPTION
The workaround is ugly, but it seems like the only possible standards-compliant way to do it without activating C++11 mode.

Fixes #67.