### PR TITLE
Add error: "Lists can't contain lists".

### DIFF
--- a/final_walk.cc
+++ b/final_walk.cc
@@ -100,6 +100,26 @@ void check_cond(LLScriptExpression *expr, bool warn_if_true) {
    }
 }
 
+void LLScriptListExpression::final_pre_checks() {
+   LLASTNode *elem;
+   for ( elem = get_children(); elem; elem = elem->get_next() )
+      if ( elem->get_type()->get_itype() == LST_LIST )
+          ERROR( IN(elem), E_LIST_IN_LIST );
+}
+
+void LLScriptListConstant::final_pre_checks() {
+   LLASTNode *elem;
+   for ( elem = get_children(); elem; elem = elem->get_next() ) {
+      if ( elem->get_type()->get_itype() == LST_LIST ) {
+         if (elem->get_node_type() == NODE_SIMPLE_ASSIGNABLE) {
+            ERROR( IN(elem->get_child(0)), E_LIST_IN_LIST );
+         } else {
+            ERROR( IN(elem), E_LIST_IN_LIST );
+         }
+      }
+   }
+}
+
 void LLScriptIfStatement::final_pre_checks() {
    check_cond((LLScriptExpression*)get_child(0), true);
 }

--- a/logger.cc
+++ b/logger.cc
@@ -134,11 +134,11 @@ void Logger::logv(LogLevel level, YYLTYPE *yylloc, const char *fmt, va_list args
 
    if (file_path != NULL)
    {
-      bp += sprintf(bp, "%s::", file_path); 
+      bp += sprintf(bp, "%s::", file_path);
    }
    bp += sprintf(bp, "%5s:: ", type );
-   if ( yylloc != NULL ) { 
-      bp += sprintf(bp, "(%3d,%3d)", yylloc->first_line, yylloc->first_column); 
+   if ( yylloc != NULL ) {
+      bp += sprintf(bp, "(%3d,%3d)", yylloc->first_line, yylloc->first_column);
       if ( show_end )
          bp += sprintf(bp, "-(%3d,%3d)", yylloc->last_line, yylloc->last_column);
       bp += sprintf(bp, ": ");
@@ -223,7 +223,7 @@ void LogMessage::cont( char *message ) {
 void LogMessage::print( FILE *fp ) {
    std::vector<char*>::const_iterator i;
    for ( i = messages.begin(); i != messages.end(); ++i ) {
-      if ( i != messages.begin() ) 
+      if ( i != messages.begin() )
          fprintf( fp, "%20s", "");
       fprintf( fp, "%s\n", *i );
    }
@@ -284,6 +284,7 @@ const char *Logger::error_messages[] = {
    "Case type incompatible with switch type.",                        // 10035
    "Declaration needs braces {}.",                                    // 10036
    "`%s' requires god mode. Use lslint -G to enable god mode.",       // 10037
+   "Lists can't contain lists.",                                      // 10038
 
 };
 

--- a/logger.hh
+++ b/logger.hh
@@ -86,6 +86,7 @@ enum ErrorCode {
     E_INCOMPATIBLE_CASE_TYPE,          // 10035
     E_DECLARATION_NOT_ALLOWED,         // 10036
     E_GOD_MODE_FUNCTION,               // 10037
+    E_LIST_IN_LIST,                    // 10038
     E_LAST
 
 

--- a/lslmini.hh
+++ b/lslmini.hh
@@ -235,6 +235,8 @@ class LLScriptListConstant : public LLScriptConstant {
       return i;
     }
 
+    virtual void final_pre_checks();
+
     virtual LLScriptConstant *operation(int op, LLScriptConstant *other_const, YYLTYPE *lloc);
 
   private:
@@ -593,6 +595,7 @@ class LLScriptListExpression : public LLScriptExpression {
     virtual void determine_value();
     virtual const char *get_node_name() { return "list expression"; };
     virtual LLNodeSubType get_node_sub_type() { return NODE_LIST_EXPRESSION; }
+    virtual void final_pre_checks();
 };
 
 class LLScriptLValueExpression : public LLScriptExpression {

--- a/scripts/bugs/0019.lsl
+++ b/scripts/bugs/0019.lsl
@@ -16,8 +16,8 @@ default {
                                                         PARCEL_DETAILS_DESC, PARCEL_DETAILS_OWNER,
                                                         PARCEL_DETAILS_GROUP, PARCEL_DETAILS_AREA ] );
 
-        list    use_stuff = [ prim_count, prim_owners, parcel_max_prims,
-                              parcel_prim_count, parcel_details,
+        list    use_stuff = [ prim_count, prim_owners, parcel_max_prims, // $[E10038] lists can't contain lists
+                              parcel_prim_count, parcel_details,         // $[E10038]
                               PARCEL_FLAG_RESTRICT_PUSHOBJECT |
                               REGION_FLAG_RESTRICT_PUSHOBJECT ];
 

--- a/scripts/bugs/0036.lsl
+++ b/scripts/bugs/0036.lsl
@@ -1,0 +1,27 @@
+list g1;
+key a = "";
+list g2 = [1, 2, 3, a];
+list g3 = [1, 2, 3,
+                    g2   // $[E10038] Lists can't contain lists
+                      ];
+list g4 =
+          [              // $[E10020] Global initializer must be constant
+                         // (in globals, the syntax doesn't allow [[]])
+           []];
+
+default{timer(){
+  g1 = [
+        g2               // $[E10038]
+          ,
+           g3            // $[E10038]
+             ,
+              llGetPrimitiveParams      // $[E10038]
+                                  ([])];
+  g2 = [
+        [                // $[E10038]
+         ]];
+
+  g3 = [
+        (                // $[E10038]
+         list)0];
+}}


### PR DESCRIPTION
Applies to list constants and list constructors where one of the elements is of type list.

Closes #36, with the difference that it's an error instead of a warning as suggested in #69.

My editor removes spaces at EOL, so that part slipped into the PR, sorry for the extra noise.