### PR TITLE
Define the symbol anyway when a declaration appears at an illegal place

### DIFF
--- a/lslmini.cc
+++ b/lslmini.cc
@@ -244,7 +244,7 @@ void LLScriptDeclaration::define_symbols() {
    if (   type == NODE_IF_STATEMENT || type == NODE_FOR_STATEMENT
        || type == NODE_DO_STATEMENT || type == NODE_WHILE_STATEMENT) {
       ERROR( HERE, E_DECLARATION_NOT_ALLOWED );
-      return;
+      // fall through to define the symbol anyway (issue #73)
    }
    LLScriptIdentifier *identifier = (LLScriptIdentifier *)get_children();
    identifier->set_symbol( new LLScriptSymbol(identifier->get_name(), identifier->get_type(), SYM_VARIABLE, SYM_LOCAL, identifier->get_lloc()) );

--- a/scripts/bugs/0073.lsl
+++ b/scripts/bugs/0073.lsl
@@ -1,0 +1,6 @@
+default{timer(){
+  if (llGetLinkNumber())
+     integer           // $[E10036] Declaration needs braces {}
+             i         // $[E20009] Declared but not used
+               = 0;
+}}

--- a/scripts/scope3.lsl
+++ b/scripts/scope3.lsl
@@ -4,6 +4,6 @@ default {
         integer test = 1; // works fine
         test();
         test = 2;
-        if (llGetAttached()) integer test; // $[E10036], but no E10001
+        if (llGetAttached()) integer test; // $[E10036], $[E10001]
     }
 }


### PR DESCRIPTION
Fixes #73.
