### PR TITLE
Add warning for (list)string_var or (list)key_var in LSO

### DIFF
--- a/final_walk.cc
+++ b/final_walk.cc
@@ -120,6 +120,27 @@ void LLScriptListConstant::final_pre_checks() {
    }
 }
 
+void LLScriptTypecastExpression::final_pre_checks() {
+   if (!mono_mode && get_type()->get_itype() == LST_LIST) {
+      // Check if it only has a variable of type string or key
+      LLASTNode *child = get_children();
+      if (child && !child->get_next() && child->get_node_type() == NODE_EXPRESSION && child->get_node_sub_type() == NODE_LVALUE_EXPRESSION) {
+         // We're on the right track. Go one level deeper.
+         child = child->get_children();
+         if (child && !child->get_next() && child->get_node_type() == NODE_IDENTIFIER) {
+            LST_TYPE type = child->get_type()->get_itype();
+            // A-ha!
+            if (type == LST_STRING) {
+                ERROR(HERE, W_KEY_OR_STR_TO_LIST, "string", "key", "string");
+            }  else if (type == LST_KEY) {
+                ERROR(HERE, W_KEY_OR_STR_TO_LIST, "key", "string", "key");
+            }
+         }
+      }
+
+   }
+}
+
 void LLScriptIfStatement::final_pre_checks() {
    check_cond((LLScriptExpression*)get_child(0), true);
 }

--- a/final_walk.cc
+++ b/final_walk.cc
@@ -49,9 +49,9 @@ void LLScriptGlobalFunction::final_pre_checks() {
    }
 
    if (id->get_symbol() != NULL) {
-      LLScriptType *tipe = id->get_symbol()->get_type();
+      LLScriptType *type = id->get_symbol()->get_type();
 
-      if (tipe->get_itype() != LST_NULL && !allret(statement)) {
+      if (type->get_itype() != LST_NULL && !allret(statement)) {
          ERROR(IN(get_child(0)), E_NOT_ALL_PATHS_RETURN);
       }
    }

--- a/logger.cc
+++ b/logger.cc
@@ -317,4 +317,6 @@ const char *Logger::warning_messages[] = {
    "Prefixing a string with L will cause a double quote (\")\n"
      "to be inserted at the beginning of the string.",                // 20019
    "print does nothing. Attempting to use the result %s.\n",          // 20020
+   "In LSO, (list)%s_var can result in a variable of type %s in the list."
+     " Use [%s_var] instead.",                                      // 20021
 };

--- a/logger.hh
+++ b/logger.hh
@@ -113,6 +113,7 @@ enum ErrorCode {
     W_DUPLICATE_CASE,                  // 20018
     W_L_STRING,                        // 20019
     W_PRINT,                           // 20020
+    W_KEY_OR_STR_TO_LIST,              // 20021
     W_LAST
 
 };

--- a/lslmini.hh
+++ b/lslmini.hh
@@ -547,6 +547,7 @@ class LLScriptTypecastExpression : public LLScriptExpression {
     virtual void determine_type() {}; // type already determined
     virtual const char *get_node_name() { return "typecast expression"; }
     virtual LLNodeSubType get_node_sub_type() { return NODE_TYPECAST_EXPRESSION; };
+    virtual void final_pre_checks();
 };
 
 class LLScriptFunctionExpression : public LLScriptExpression {

--- a/scripts/lso/liststrkey.lsl
+++ b/scripts/lso/liststrkey.lsl
@@ -1,0 +1,22 @@
+default
+{
+    state_entry()
+    {
+        key k = llGetObjectName();
+        string s = llGetKey();
+
+        list ls =
+                  (list)    // $[E20021] could result in a string
+                        k;
+        ls = ls +
+                  (list)         // $[E20021] could result in a key
+                        s;
+
+        if (llGetListEntryType(ls, 0) == TYPE_STRING
+         && llGetListEntryType(ls, 1) == TYPE_KEY)
+        {
+            // This is printed!
+            llOwnerSay("LSO has weird bugs");
+        }
+    }
+}

--- a/scripts/mono/liststrkey.lsl
+++ b/scripts/mono/liststrkey.lsl
@@ -1,0 +1,18 @@
+default
+{
+    state_entry()
+    {
+        key k = llGetObjectName();
+        string s = llGetKey();
+
+        list ls = (list)k;  // no E20021 in mono
+        ls = ls + (list)s;  // no E20021 in mono
+
+        if (llGetListEntryType(ls, 0) != TYPE_STRING
+         && llGetListEntryType(ls, 1) != TYPE_KEY)
+        {
+            // Printed in Mono because it's safe
+            llOwnerSay("Mono is safe");
+        }
+    }
+}

--- a/types.hh
+++ b/types.hh
@@ -35,7 +35,7 @@ class LLScriptType : public LLASTNode {
     bool can_coerce( LLScriptType *to );
     LLScriptType *get_result_type(int op,  LLScriptType *right);
 
-    int get_itype() { return itype; } ;
+    LST_TYPE get_itype() { return itype; } ;
     virtual const char *get_node_name() {
       switch (itype) {
         case LST_ERROR:         return "error";


### PR DESCRIPTION
This implements the warning suggested in #35.

Here's a test case that triggers it:

```lsl
default
{
    state_entry()
    {
        key k = llGetObjectName();
        string s = llGetKey();
        list lst =
                   (list)    // $[E20021] could result in a string
                         k;
        lst = lst +
                    (list)         // $[E20021] could result in a key
                          s;
        if (llGetListEntryType(lst, 0) == TYPE_STRING
         && llGetListEntryType(lst, 1) == TYPE_KEY)
        {
            // This is printed!
            llOwnerSay("LSO has weird bugs");
        }
    }
}
```

If the above script is compiled with Mono mode *disabled*, it will output "LSO has weird bugs".

Contains also a couple very minor changes which are not worth a PR.