### PR TITLE
Fix segfault when recovering from syntax error after the last global

### DIFF
--- a/lslmini.y
+++ b/lslmini.y
@@ -242,17 +242,13 @@ globals
 	}
 	| global globals
 	{
-		if ( $1 ) {
+		if ( $1 && $2 ) {
 			DEBUG( LOG_DEBUG_SPAM, NULL, "** global [%p,%p] globals [%p,%p]\n", $1->get_prev(), $1->get_next(), $2->get_prev(), $2->get_next());
 			$1->add_next_sibling($2);
 			$$ = $1;
 		} else {
-			$$ = $2;
+			$$ = $2 ? $2 : $1;
 		}
-	}
-	| error ';'
-	{
-		$$ = NULL;
 	}
 	;
 
@@ -264,6 +260,10 @@ global
 	| global_function
 	{
 		$$ = new LLScriptGlobalStorage(NULL, $1);
+	}
+	| error ';'
+	{
+		$$ = NULL;
 	}
 	;
 

--- a/scripts/bugs/0079a.lsl
+++ b/scripts/bugs/0079a.lsl
@@ -1,0 +1,3 @@
+integer a; // $[E20009] Declared but not used
+b;         // $[E10019] Syntax error (it was causing a segfault)
+default { state_entry() {} }

--- a/scripts/bugs/0079b.lsl
+++ b/scripts/bugs/0079b.lsl
@@ -1,0 +1,4 @@
+integer a; // $[E20009] Declared and not used
+b;         // $[E10019] Syntax error
+integer c; // $[E20009] Declared and not used
+default { state_entry() {} }


### PR DESCRIPTION
Per bug report by @thickbrick.

Fixes #79, and another issue with globals not being always declared in case of syntax error.