### PR TITLE
Emit error when variables are used before being declared where appropriate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ OBJS = lslmini.tab.o lex.yy.o lslmini.o symtab.o builtins.o builtins_txt.o types
 all: $(PROGRAM)
 
 $(PROGRAM): $(OBJS)
-	$(LD) $(LDOUTPUT)"$@" $^
+	$(LD) $(LDFLAGS) $(LDOUTPUT)"$@" $^
 	$(UPX) "$@"
 
 clean:
@@ -122,6 +122,6 @@ lex.yy.c: lslmini.l
 	$(LEX) lslmini.l
 
 .c.o .cc.o:
-	$(CXX) $(CXXOUTPUT)"$@" -c $<
+	$(CXX) $(CXXFLAGS) $(CXXOUTPUT)"$@" -c $<
 
 .PHONY: all clean check

--- a/ast.hh
+++ b/ast.hh
@@ -178,8 +178,8 @@ class LLASTNode {
     void propagate_values();
     virtual void determine_value();
 
-    // final pre walk checks    TODO: come up with a better name?
-    void final_pre_walk();
+    // final walk checks
+    void final_walk();
     virtual void final_pre_checks() {};
     virtual void final_post_checks() {};
 

--- a/builtins.cc
+++ b/builtins.cc
@@ -4,7 +4,7 @@
 #include "lslmini.hh"
 #include "logger.hh"
 
-char *builtins_file = NULL;
+const char *builtins_file = NULL;
 extern const char *builtins_txt[];
 
 struct _TypeMap {

--- a/builtins.cc
+++ b/builtins.cc
@@ -150,6 +150,8 @@ void LLScriptScript::define_builtins() {
          }
          symbol->set_constant_value(constant);
          define_symbol(symbol);
+         symbol->set_declared();
+         symbol->set_global();
       }
       else if (!strcmp(ret_type, "event")) {
          name     = strtok(NULL, " (),");

--- a/final_walk.cc
+++ b/final_walk.cc
@@ -1,10 +1,10 @@
 #include "lslmini.hh"
 
-void LLASTNode::final_pre_walk() {
+void LLASTNode::final_walk() {
    LLASTNode *node;
    final_pre_checks();
    for ( node = get_children(); node; node = node->get_next() )
-      node->final_pre_walk();
+      node->final_walk();
    final_post_checks();
 }
 

--- a/lslmini.cc
+++ b/lslmini.cc
@@ -1077,12 +1077,12 @@ nextarg:
       }
 
       LOG(LOG_INFO, NULL, "Script parsed, collecting symbols");
-      script->collect_symbols();
+      script->collect_symbols();    // in this file
       LOG(LOG_INFO, NULL, "Propagating types");
-      script->propagate_types();
-      script->propagate_values();
-      script->check_symbols();
-      script->final_pre_walk();
+      script->propagate_types();    // in this file
+      script->propagate_values();   // in values.cc
+      script->check_symbols();      // in this file, calls symtab.cc
+      script->final_walk();         // in final_walk.cc
       Logger::get()->report();
       if ( show_tree ) {
          LOG(LOG_INFO, NULL, "Tree:");

--- a/lslmini.cc
+++ b/lslmini.cc
@@ -39,7 +39,7 @@ std::string getBuildDate() {
 }
 
 extern FILE *yyin;
-extern char *builtins_file;
+extern const char *builtins_file;
 //extern int yynerrs;
 int yynwarns = 0;                // not defined by flex but named for consistency
 
@@ -396,8 +396,8 @@ void LLScriptExpression::determine_type() {
 //      integer test = 1;
 //      llOwnerSay(test());
 //    }
-//  But if "test" looked itself up, it would think it is an integer. It's parent function
-//  expression node can tell it what it needs to be before determining it's own type.
+//  But if "test" looked itself up, it would think it is an integer. Its parent function
+//  expression node can tell it what it needs to be before determining its own type.
 void LLScriptIdentifier::resolve_symbol(LLSymbolType symbol_type) {
 
    // If we already have a symbol, we don't need to look it up.
@@ -529,7 +529,7 @@ void LLScriptIdentifier::resolve_symbol(LLSymbolType symbol_type) {
          return;
       }
 
-      /// Make sure it's a variable
+      // Make sure it's a variable
       if ( symbol_type != SYM_VARIABLE ) {
          ERROR( HERE, E_MEMBER_NOT_VARIABLE, name, member, LLScriptSymbol::get_type_name(symbol_type));
          symbol = NULL;
@@ -852,7 +852,7 @@ void LLASTNode::check_symbols() {
 }
 
 
-void usage(char *name) {
+void usage(const char *name) {
    printf("Usage: %s [options] [input]\n", name);
    printf("Options: \n");
    printf("\t-m\t\tFlag: Use Mono rules for the analysis (default on)\n");
@@ -929,7 +929,7 @@ int yylex_init( void ** );
 void yyset_in( FILE *, void *);
 int yylex_destroy( void *) ;
 
-int main(int argc, char **argv) {
+int main(int argc, const char **argv) {
    int i, j;
    FILE *yyin = NULL;
    bool show_tree = false;
@@ -946,7 +946,7 @@ int main(int argc, char **argv) {
    // HACK: Parse long options before anything else.
    for ( i = 1; i < argc; ++i ) {
       if (argv[i][0] == '-' && argv[i][1] == '-') {
-         char *optiontext = argv[i] + 2;
+         const char *optiontext = argv[i] + 2;
          if ( !strcmp(optiontext, "version") ) {
             short_version();
             return 0;

--- a/lslmini.hh
+++ b/lslmini.hh
@@ -91,7 +91,7 @@ class LLScriptIdentifier : public LLASTNode {
 
     void determine_value();
 
-    void resolve_symbol(LLSymbolType symbol_type);
+    void resolve_symbol(LLSymbolType symbol_type, bool is_simple = false);
     void set_symbol( LLScriptSymbol *_symbol ) { symbol = _symbol; };
     LLScriptSymbol *get_symbol() { return symbol; };
 

--- a/scripts/scope4.lsl
+++ b/scripts/scope4.lsl
@@ -1,0 +1,58 @@
+// Visibility rules
+
+integer a = b;   // $[E10006] Not defined
+integer x = x;   // $[E10006] Not defined (checks pre/post order correctness)
+
+fn1(integer x)   // $[E20001] shadows global x
+{
+    // All globals are visible by functions, regardless of order
+    a;              // ok
+    b;              // ok
+    x;              // ok
+    fn2();          // ok
+    integer x = 1;  // $[E20001] shadows parameter x
+    if (x) x;       // $[E20011] condition always true
+
+    // Locals are only accessible after their declaration
+    c;              // $[E10006] Not defined
+    {
+        c;          // $[E10006] Not defined
+    }
+    integer c;      // defined here
+    c;              // ok
+    {
+        // Visible on inner blocks
+        c;          // ok;
+        d;          // $[E10006] Not defined
+        integer d;  // defined here
+        d;          // ok
+    }
+    // d goes out of scope when closing the above block
+    d;              // $[E10006] Not defined
+
+    // Labels are visible before being declared, but not in nested blocks
+    jump f;         // $[E10006] Not defined
+    {
+        jump f;     // ok
+        @f;
+        @g;
+        jump h;     // ok
+        jump g;     // ok
+    }
+    @h;
+    @j;
+
+    jump f;         // $[E10006] Not defined
+    jump j;         // ok
+    if (TRUE)       // $[E20011] Condition is always true
+        state b;    // $[E20005] side effects, $[E10005] is a variable
+}
+
+fn2() {}
+
+integer b;
+
+default{timer(){ fn1(1); x; }}
+
+state b             // $[E10001] Already defined
+{timer(){}}

--- a/symtab.hh
+++ b/symtab.hh
@@ -11,11 +11,13 @@ class LLScriptSymbol {
   public:
     LLScriptSymbol( const char *name, class LLScriptType *type, LLSymbolType symbol_type, LLSymbolSubType sub_type, YYLTYPE *lloc, class LLScriptFunctionDec *function_decl = NULL )
       : name(name), type(type), symbol_type(symbol_type), sub_type(sub_type), lloc(*lloc), function_decl(function_decl),
-      constant_value(NULL), references(0), assignments(0), cur_references(0) {};
+      constant_value(NULL), references(0), assignments(0), cur_references(0),
+      declared(false), global(false) {};
 
     LLScriptSymbol( const char *name, class LLScriptType *type, LLSymbolType symbol_type, LLSymbolSubType sub_type, class LLScriptFunctionDec *function_decl = NULL )
       : name(name), type(type), symbol_type(symbol_type), sub_type(sub_type), function_decl(function_decl),
-      constant_value(NULL), references(0), assignments(0), cur_references(0) {
+      constant_value(NULL), references(0), assignments(0), cur_references(0),
+      declared(false), global(false) {
           static const YYLTYPE zero_lloc = {};
           lloc = zero_lloc;
     };
@@ -28,6 +30,10 @@ class LLScriptSymbol {
     int                  add_reference()    { return ++references; }
     int                  get_assignments()  { return assignments; }
     int                  add_assignment()   { return ++assignments; }
+    bool                 was_declared()     { return declared; }
+    void                 set_declared()     { declared = true; }
+    bool                 is_global()        { return global; }
+    void                 set_global()       { global = true; }
 
     LLSymbolType         get_symbol_type()  { return symbol_type; }
     LLSymbolSubType      get_sub_type()     { return sub_type;    }
@@ -60,6 +66,8 @@ class LLScriptSymbol {
     int                  references;            // how many times this symbol is referred to
     int                  assignments;           // how many times it is assigned to
     int                  cur_references;        // how many times the current const_value was referred to
+    bool                 declared;              // was it declared before?
+    bool                 global;                // is it a global symbol?
 };
 
 class LLScriptSymbolTable {


### PR DESCRIPTION
#78 is a nasty one, due to LSL visibility rules.

lslint performs a first pass over the AST for gathering symbols, and then it performs a second pass checking for missing ones.

This actually works well in *most* situations, surprisingly, because every symbol type except variables does work like that in LSL: labels, functions and states are visible from anywhere within the same or a nested scope level. Even in some situations variables also behave that way: globals can be seen by functions before being declared.

However, it prominently works wrong in the two situations reported in #78, and these MUST be fixed:
- Globals that have not yet been declared can't be seen in the right hand side of other globals.
- Locals that have not yet been declared can't be seen at all.

The test case included in this PR shows these rules in action.

The solution chosen in this PR is to act "as if" it did not exist: it's not enough that looking up a symbol returns a valid one; we also need to check if that symbol is visible. For that, we add two fields to each symbol table entry: `global` and `declared`. The `global` field is set during the symbol scanning pass, to help distinguishing later whether a variable is visible inside UDFs because it's global. The `declared` field is set during the second pass, and tells whether a variable has been declared at the point it is seen or not, which helps determining whether it's visible.

Some minor cleanups are included too.