### PR TITLE
Add warning/error about uninitialized globals

### DIFF
--- a/builtins.cc
+++ b/builtins.cc
@@ -152,6 +152,7 @@ void LLScriptScript::define_builtins() {
          define_symbol(symbol);
          symbol->set_declared();
          symbol->set_global();
+         symbol->set_initialized();
       }
       else if (!strcmp(ret_type, "event")) {
          name     = strtok(NULL, " (),");

--- a/logger.cc
+++ b/logger.cc
@@ -287,6 +287,7 @@ const char *Logger::error_messages[] = {
    "Lists can't contain lists.",                                      // 10038
    "Label `%s' already defined in this function or event prevents saving"
       " the program",                                                 // 10039
+   "Uninitialized variables can't be included in lists in LSO",       // 10040
 
 };
 
@@ -323,5 +324,7 @@ const char *Logger::warning_messages[] = {
      " Use [%s_var] instead.",                                        // 20021
    "Label `%s' already defined in this function or event may cause"
       " unexpected behaviour (jumps will go to the last label found)",// 20022
+   "Initializing a global key or string using an uninitialized"
+      " variable causes a runtime error when accessing it",           // 20023
 
 };

--- a/logger.hh
+++ b/logger.hh
@@ -87,7 +87,8 @@ enum ErrorCode {
     E_DECLARATION_NOT_ALLOWED,         // 10036
     E_GOD_MODE_FUNCTION,               // 10037
     E_LIST_IN_LIST,                    // 10038
-    E_DUPLICATE_LABEL_MONO,            // 10040
+    E_DUPLICATE_LABEL_MONO,            // 10039
+    E_UNINITIALIZED_VAR_IN_LIST,       // 10040
     E_LAST
 
 
@@ -116,6 +117,7 @@ enum ErrorCode {
     W_PRINT,                           // 20020
     W_KEY_OR_STR_TO_LIST,              // 20021
     W_DUPLICATE_LABEL_LSO,             // 20022
+    W_UNINITIALIZED_VAR_IN_STR_KEY,    // 20023
     W_LAST
 
 };

--- a/lslmini.l
+++ b/lslmini.l
@@ -44,10 +44,18 @@ FS			(f|F)
 	LLOC_STEP();
 %}
 "//"                { BEGIN COMMENT; }
-<COMMENT,C_COMMENT>"$[E"{N}{5}"]" {
+<COMMENT,C_COMMENT>"$["[EML]{N}{5}"]" {
 		ErrorCode e = (ErrorCode) strtoul( yytext+3, NULL, 10 );
-		LOG( LOG_INFO, yylloc, "Adding assertion for E%d.", (int)e );
-		Logger::get()->add_assertion( yylloc->first_line, e );
+		if ((mono_mode && yytext[2] != 'L') || (!mono_mode && yytext[2] != 'M')) {
+			LOG( LOG_INFO, yylloc, "Adding%s assertion for %d.",
+				yytext[2] == 'L' ? " LSO-only" :
+				yytext[2] == 'M' ? " Mono-only" : "", (int)e );
+			Logger::get()->add_assertion( yylloc->first_line, e );
+		} else {
+			LOG( LOG_INFO, yylloc, "Ignoring%s assertion for %d.",
+				yytext[2] == 'L' ? " LSO-only" :
+				yytext[2] == 'M' ? " Mono-only" : "", (int)e );
+		}
 	}
 <COMMENT>.			{ /* eat comments */ }
 <COMMENT>\n			{ BEGIN 0; LLOC_LINES(1); LLOC_STEP(); }
@@ -177,7 +185,7 @@ char *parse_string(char *input, int *last_line, int *last_column) {
 	while ( *yp ) {
 		if ( *yp == '\\' ) {
 			++*last_column;
-			switch ( *++yp ) { 
+			switch ( *++yp ) {
 					case 'n':  *sp++ = '\n'; break;
 					case 't':
 						*sp++ = ' ';

--- a/scripts/globals.lsl
+++ b/scripts/globals.lsl
@@ -34,16 +34,21 @@ string good_s00;
 string good_s01 = "ok";
 string good_s02 = L"x";      // $[E20019] prepends quote, like "x
 string good_s03 = good_s01;
-string good_s04 = good_s00;  // TODO: Should emit warning in LSO
+string good_s04 = good_s00;  // $[L20023] can cause runtime error
 key good_k00;
-string good_s05 = good_k00;  // TODO: Should emit warning in LSO
+string good_s05 = good_k00;  // $[L20023] can cause runtime error
 key good_k01 = "ok";
 string good_s06 = good_k01;
 key good_k02 = L"x";         // $[E20019]
-key good_k03 = good_s00;     // TODO: Should emit warning in LSO
+key good_k03 = good_s00;     // $[L20023] can cause runtime error
 key good_k04 = good_s01;
 key good_k05 = good_k01;
-key good_k06 = good_k00;     // TODO: Should emit warning in LSO
+key good_k06 =
+               good_k00      // $[L20023] can cause runtime error
+                       ;
+list lso_bad_l01 = [<good_i00, good_f00, 1>,
+                    good_s00 // $[L10040] uninitialized in lists
+                            ];
 
 vector good_v00;
 vector good_v01 = <0, 0, 0>;
@@ -82,7 +87,7 @@ vector bad_r01 = -r00;       // $[E10020]
 vector bad_r02 = <good_r01.x, good_r01.y, good_r01.z, good_r01.s>; // $[E10020]
 list bad_l01 = [-TRUE];      // $[E10020]
 list bad_l02 = [-<1,1,1>];   // $[E10020]
-list bad_l03 = [1,[2,3],4];  // $[E10020] TODO: add "Lists can't contain lists"
+list bad_l03 = [1,[2,3],4];  // $[E10020]
 list bad_l04 = -[1];         // $[E10020] (dubious - E10002 would be more appropriate here)
 list bad_l05 = [good_v01.x]; // $[E10020]
 
@@ -161,6 +166,7 @@ good_v00; good_v01; good_v02; good_v03;
 good_l00; good_l01; good_l02;
 
 bad_v02;
+lso_bad_l01;
 llSetPrimitiveParams(I_am_also_used);
 
 }}

--- a/symtab.hh
+++ b/symtab.hh
@@ -12,12 +12,12 @@ class LLScriptSymbol {
     LLScriptSymbol( const char *name, class LLScriptType *type, LLSymbolType symbol_type, LLSymbolSubType sub_type, YYLTYPE *lloc, class LLScriptFunctionDec *function_decl = NULL )
       : name(name), type(type), symbol_type(symbol_type), sub_type(sub_type), lloc(*lloc), function_decl(function_decl),
       constant_value(NULL), references(0), assignments(0), cur_references(0),
-      declared(false), global(false) {};
+      declared(false), global(false), initialized(false) {};
 
     LLScriptSymbol( const char *name, class LLScriptType *type, LLSymbolType symbol_type, LLSymbolSubType sub_type, class LLScriptFunctionDec *function_decl = NULL )
       : name(name), type(type), symbol_type(symbol_type), sub_type(sub_type), function_decl(function_decl),
       constant_value(NULL), references(0), assignments(0), cur_references(0),
-      declared(false), global(false) {
+      declared(false), global(false), initialized(false) {
           static const YYLTYPE zero_lloc = {};
           lloc = zero_lloc;
     };
@@ -34,6 +34,8 @@ class LLScriptSymbol {
     void                 set_declared()     { declared = true; }
     bool                 is_global()        { return global; }
     void                 set_global()       { global = true; }
+    bool                 is_initialized()   { return initialized; }
+    void                 set_initialized()  { initialized = true; }
 
     LLSymbolType         get_symbol_type()  { return symbol_type; }
     LLSymbolSubType      get_sub_type()     { return sub_type;    }
@@ -68,6 +70,7 @@ class LLScriptSymbol {
     int                  cur_references;        // how many times the current const_value was referred to
     bool                 declared;              // was it declared before?
     bool                 global;                // is it a global symbol?
+    bool                 initialized;           // (for globals) is there an initializer?
 };
 
 class LLScriptSymbolTable {


### PR DESCRIPTION
In lists, they produce a compile-time error.

In strings and keys, they can produce a run-time error.

Closes #39.

This PR also adds Mono-only and LSO-only assertions, in addition to the normal assertions, so that they only trigger when `-m` or `-m-` is in effect. An assertion of the form `$[L...]` is LSO-only and will be ignored in Mono mode, and one of the form `$[M...]` is Mono-only and will be ignored in LSO mode.

That spares us from having to make two copies of the test file and move it to scripts/lso/ and scripts/mono/.