### PR TITLE
Give error on (string)-ZERO_VECTOR etc.

### DIFF
--- a/lslmini.y
+++ b/lslmini.y
@@ -940,7 +940,7 @@ typecast
 	| '(' typename ')' '-' IDENTIFIER
 	{
 		LLScriptSymbol *symbol = script->get_symbol_table()->lookup($5);
-		if (!symbol || symbol->get_symbol_type() != SYM_VARIABLE || symbol->get_sub_type() != SYM_BUILTIN)
+		if (!symbol || symbol->get_symbol_type() != SYM_VARIABLE || symbol->get_sub_type() != SYM_BUILTIN || symbol->get_type()->get_itype() == LST_VECTOR || symbol->get_type()->get_itype() == LST_QUATERNION)
 			ERROR(&@4, E_SYNTAX_ERROR, "Need parentheses around expression.");
 		$$ = new LLScriptTypecastExpression($2, new LLScriptExpression( new LLScriptLValueExpression( new LLScriptIdentifier($5) ), '-') );
 	}

--- a/scripts/globals.lsl
+++ b/scripts/globals.lsl
@@ -123,8 +123,11 @@ default{timer(){
 (string) - FALSE;  // $[E10019]
 (string)~1;        // $[E10019]
 (string)-<0,0,0>;  // $[E10019]
+(string)-ZERO_VECTOR;    // $[E10019]
+(string)-ZERO_ROTATION;  // $[E10019]
 (string)-good_i01; // $[E10019]
 (string)[-"nope"]; // $[E10002] invalid operator
+(string)-EOF;      // $[E10002]
 
 if (good_i00 == 0)               0; // $[E20011] always true
 if (good_i00 == good_i00)        0; // $[E20011]


### PR DESCRIPTION
Type cast of `-ZERO_VECTOR` and `-ZERO_ROTATION` were being accepted as good, because of the special treatment for constants. They raise a syntax error in LSO.

Thanks to @Jomik for spotting it.

It's a bit unfortunate that this was spotted just a few days after the last release, but it's not critical anyway.