### PR TITLE
Report E_INVALID_OPERATOR with the right order of operands

### DIFF
--- a/logger.cc
+++ b/logger.cc
@@ -248,7 +248,7 @@ LogMessage::~LogMessage() {
 const char *Logger::error_messages[] = {
    "ERROR",                                                           // 10000
    "Duplicate declaration of `%s'; previously declared at (%d, %d).", // 10001
-   "Invalid operator: %s %s %s.",                                     // 10002
+   "Invalid operator: %s%s%s%s%s.",                                   // 10002
    "`%s' is deprecated.",                                             // 10003
    "`%s' is deprecated, use %s instead.",                             // 10004
    "Attempting to use `%s' as a %s, but it is a%s %s.",               // 10005

--- a/lslmini.cc
+++ b/lslmini.cc
@@ -359,7 +359,9 @@ static const char* operation_str(int operation) {
    static char buf[16+1];
    switch (operation) {
       case EQ:            return "==";
+      case POSTINC_OP:
       case INC_OP:        return "++";
+      case POSTDEC_OP:
       case DEC_OP:        return "--";
       case BOOLEAN_AND:   return "&&";
       case BOOLEAN_OR:    return "||";
@@ -381,7 +383,16 @@ void LLScriptExpression::determine_type() {
    else {
       type = get_child(0)->get_type()->get_result_type( operation, get_child(1) ? get_child(1)->get_type() : NULL );
       if ( type == NULL ) {
-         ERROR( HERE, E_INVALID_OPERATOR, get_child(0)->get_type()->get_node_name(), operation_str(operation), get_child(1) ? get_child(1)->get_type()->get_node_name() : "" );
+         if (get_child(1)) {
+            // Binary operator
+            ERROR( HERE, E_INVALID_OPERATOR, get_child(0)->get_type()->get_node_name(), " ", operation_str(operation), " ", get_child(1)->get_type()->get_node_name() );
+         } else if (operation == POSTINC_OP || operation == POSTDEC_OP) {
+            // Unary postfix operator
+            ERROR( HERE, E_INVALID_OPERATOR, get_child(0)->get_type()->get_node_name(), " ", operation_str(operation), "", "" );
+         } else {
+            // Unary prefix operator
+            ERROR( HERE, E_INVALID_OPERATOR, operation_str(operation), " ", get_child(0)->get_type()->get_node_name(), "", "" );
+         }
          // Assign a reasonable type based on operation
          LST_TYPE t = operation == EQ ? LST_INTEGER :
             operation == NEQ ? LST_INTEGER :
@@ -401,7 +412,7 @@ void LLScriptExpression::determine_type() {
             LST_NULL;
          type = t == LST_NULL ? get_child(0)->get_type() : new LLScriptType(t);
       } else {
-         if ( operation == '=' || operation == INC_OP || operation == DEC_OP ) {
+         if ( operation == '=' || operation == INC_OP || operation == DEC_OP || operation == POSTINC_OP || operation == POSTDEC_OP ) {
             // unused variable // LLASTNode *last_node     = this;
             // unused variable // LLASTNode *node          = get_parent();
 

--- a/lslmini.y
+++ b/lslmini.y
@@ -95,6 +95,8 @@
 
 %token					INC_OP
 %token					DEC_OP
+%token					POSTINC_OP
+%token					POSTDEC_OP
 %token					ADD_ASSIGN
 %token					SUB_ASSIGN
 %token					MUL_ASSIGN
@@ -993,11 +995,11 @@ unarypostfixexpression
 	}
 	| lvalue INC_OP
 	{
-		$$ = new LLScriptExpression(  $1 , INC_OP );
+		$$ = new LLScriptExpression(  $1 , POSTINC_OP );
 	}
 	| lvalue DEC_OP
 	{
-		$$ = new LLScriptExpression(  $1 , DEC_OP );
+		$$ = new LLScriptExpression(  $1 , POSTDEC_OP );
 	}
 	| IDENTIFIER '(' funcexpressionlist ')'
 	{

--- a/operators.cc
+++ b/operators.cc
@@ -9,6 +9,8 @@ LLScriptConstant *LLScriptIntegerConstant::operation(int operation, LLScriptCons
       switch (operation) {
          case INC_OP:  nv = value + 1; break;
          case DEC_OP:  nv = value - 1; break;
+         case POSTINC_OP: case POSTDEC_OP:
+                       nv = value;     break;
          case '!':     nv = !value;    break;
          case '~':     nv = ~value;    break;
          case '-':     nv = -value;    break;
@@ -73,6 +75,8 @@ LLScriptConstant *LLScriptFloatConstant::operation(int operation, LLScriptConsta
       switch (operation) {
          case INC_OP:  nv = value + 1; break;
          case DEC_OP:  nv = value - 1; break;
+         case POSTINC_OP: case POSTDEC_OP:
+                       nv = value;     break;
          case '-':     nv = -value;    break;
          default:      return NULL;
       }

--- a/types.cc
+++ b/types.cc
@@ -21,11 +21,15 @@ const static int operator_result_table[][4] = {
    // operator   left type           right type          result type
    // ++
    { INC_OP,     LST_INTEGER,        LST_NONE,           LST_INTEGER         },
+   { POSTINC_OP, LST_INTEGER,        LST_NONE,           LST_INTEGER         },
    { INC_OP,     LST_FLOATINGPOINT,  LST_NONE,           LST_FLOATINGPOINT   },
+   { POSTINC_OP, LST_FLOATINGPOINT,  LST_NONE,           LST_FLOATINGPOINT   },
 
    // --
    { DEC_OP,     LST_INTEGER,        LST_NONE,           LST_INTEGER         },
+   { POSTDEC_OP, LST_INTEGER,        LST_NONE,           LST_INTEGER         },
    { DEC_OP,     LST_FLOATINGPOINT,  LST_NONE,           LST_FLOATINGPOINT   },
+   { POSTDEC_OP, LST_FLOATINGPOINT,  LST_NONE,           LST_FLOATINGPOINT   },
 
    // =
    { '=',        LST_INTEGER,        LST_INTEGER,        LST_INTEGER         },


### PR DESCRIPTION
E.g.,

  "Invalid operator: ++ string."

or

  "Invalid operator: ! string."

As a hack, POSTINC_OP and POSTDEC_OP (for post-increment and post-decrement) have been introduced as tokens, even if not used in the grammar, so they can be passed as an operator to the AST.

This allows us to distinguish prefix and postfix ++ and --, to show e.g.

  "Invalid operator: string --."

when appropriate.

Test case:

```lsl
default{timer(){

-EOF;
~EOF;
!EOF;
EOF++;
++EOF;
EOF--;
--EOF;
"a"*llGetKey();

}}
```

Before:

```
ERROR:: (  3,  1): Invalid operator: string - .
ERROR:: (  4,  1): Invalid operator: string ~ .
ERROR:: (  5,  1): Invalid operator: string ! .
ERROR:: (  6,  1): Invalid operator: string ++ .
ERROR:: (  7,  1): Invalid operator: string ++ .
ERROR:: (  8,  1): Invalid operator: string -- .
ERROR:: (  9,  1): Invalid operator: string -- .
ERROR:: ( 10,  1): Invalid operator: string * key.
TOTAL:: Errors: 8  Warnings: 0
```

After:

```
ERROR:: (  3,  1): Invalid operator: - string.
ERROR:: (  4,  1): Invalid operator: ~ string.
ERROR:: (  5,  1): Invalid operator: ! string.
ERROR:: (  6,  1): Invalid operator: string ++.
ERROR:: (  7,  1): Invalid operator: ++ string.
ERROR:: (  8,  1): Invalid operator: string --.
ERROR:: (  9,  1): Invalid operator: -- string.
ERROR:: ( 10,  1): Invalid operator: string * key.
TOTAL:: Errors: 8  Warnings: 0
```

No unit tests were included because the messages are not visible by the unit test infrastructure.