### PR TITLE
Report type mismatch with != operator correctly

### DIFF
--- a/lslmini.cc
+++ b/lslmini.cc
@@ -359,6 +359,7 @@ static const char* operation_str(int operation) {
    static char buf[16+1];
    switch (operation) {
       case EQ:            return "==";
+      case NEQ:           return "!=";
       case POSTINC_OP:
       case INC_OP:        return "++";
       case POSTDEC_OP:


### PR DESCRIPTION
This script:

```lsl
default
{
    timer()
    {
        1 != "";
    }
}
```
was resulting in this output:
```
ERROR:: (  5,  9): Invalid operator: integer 289 string.
```
This one-line patch fixes it so that the output is:
```
ERROR:: (  5,  9): Invalid operator: integer != string.
```